### PR TITLE
Remove extern declerations in mli

### DIFF
--- a/lib/common_intf.ml
+++ b/lib/common_intf.ml
@@ -58,7 +58,7 @@ module type Common = sig
   module Naive_date : sig
     type t
 
-    external create : year:int -> month:int -> day:int -> t option = "rust_naive_date"
+    val create : year:int -> month:int -> day:int -> t option
     val of_date : Date.t -> t
     val of_string : string -> t
   end
@@ -72,12 +72,8 @@ module type Common = sig
   end
 
   module For_testing : sig
-    external panic : string -> unit = "rust_test_panic"
-    external raise_exception : string -> unit = "rust_test_exception"
-
-    external install_panic_hook
-      :  suppress_backtrace:bool
-      -> unit
-      = "rust_install_panic_hook"
+    val panic : string -> unit
+    val raise_exception : string -> unit
+    val install_panic_hook : suppress_backtrace:bool -> unit
   end
 end

--- a/lib/data_frame.mli
+++ b/lib/data_frame.mli
@@ -2,13 +2,13 @@ open! Core
 
 type t = Data_frame0.t
 
-external create : Series.t list -> (t, string) result = "rust_data_frame_new"
+val create : Series.t list -> (t, string) result
 val create_exn : Series.t list -> t
 val read_csv : ?schema:Schema.t -> ?try_parse_dates:bool -> string -> (t, string) result
 val read_csv_exn : ?schema:Schema.t -> ?try_parse_dates:bool -> string -> t
 val describe : ?percentiles:float list -> t -> (t, string) result
 val describe_exn : ?percentiles:float list -> t -> t
-external lazy_ : t -> Lazy_frame.t = "rust_data_frame_lazy"
+val lazy_ : t -> Lazy_frame.t
 val select : t -> exprs:Expr.t list -> (t, string) result
 val select_exn : t -> exprs:Expr.t list -> t
 val with_columns : t -> exprs:Expr.t list -> (t, string) result
@@ -22,17 +22,11 @@ val groupby
   -> (t, string) result
 
 val groupby_exn : ?is_stable:bool -> t -> by:Expr.t list -> agg:Expr.t list -> t
-external column : t -> name:string -> (Series.t, string) result = "rust_data_frame_column"
+val column : t -> name:string -> (Series.t, string) result
 val column_exn : t -> name:string -> Series.t
-
-external columns
-  :  t
-  -> names:string list
-  -> (Series.t list, string) result
-  = "rust_data_frame_column"
-
+val columns : t -> names:string list -> (Series.t list, string) result
 val columns_exn : t -> names:string list -> Series.t list
-external get_column_names : t -> string list = "rust_data_frame_get_column_names"
+val get_column_names : t -> string list
 val concat : ?how:[ `Diagonal | `Horizontal | `Vertical ] -> t list -> (t, string) result
 val concat_exn : ?how:[ `Diagonal | `Horizontal | `Vertical ] -> t list -> t
 
@@ -108,18 +102,12 @@ val sample_n
   -> (t, string) result
 
 val sample_n_exn : ?seed:int -> t -> n:int -> with_replacement:bool -> shuffle:bool -> t
-external sum : t -> t = "rust_data_frame_sum"
-external mean : t -> t = "rust_data_frame_mean"
-external median : t -> t = "rust_data_frame_median"
-external null_count : t -> t = "rust_data_frame_null_count"
-
-external explode
-  :  t
-  -> columns:string list
-  -> (t, string) result
-  = "rust_data_frame_explode"
-
+val sum : t -> t
+val mean : t -> t
+val median : t -> t
+val null_count : t -> t
+val explode : t -> columns:string list -> (t, string) result
 val explode_exn : t -> columns:string list -> t
-external schema : t -> Schema.t = "rust_data_frame_schema"
-external to_string_hum : t -> string = "rust_data_frame_to_string_hum"
+val schema : t -> Schema.t
+val to_string_hum : t -> string
 val print : t -> unit

--- a/lib/expr.mli
+++ b/lib/expr.mli
@@ -2,24 +2,24 @@ open! Core
 
 type t
 
-external col : string -> t = "rust_expr_col"
-external cols : string list -> t = "rust_expr_cols"
-external all : unit -> t = "rust_expr_all"
-external exclude : string -> t = "rust_expr_exclude"
+val col : string -> t
+val cols : string list -> t
+val all : unit -> t
+val exclude : string -> t
 val element : unit -> t
 val cast : ?strict:bool -> t -> to_:Data_type.t -> t
-external null : unit -> t = "rust_expr_null"
-external int : int -> t = "rust_expr_int"
-external float : float -> t = "rust_expr_float"
-external bool : bool -> t = "rust_expr_bool"
-external string : string -> t = "rust_expr_string"
-external naive_date : Common.Naive_date.t -> t = "rust_expr_naive_date"
-external naive_datetime : Common.Naive_datetime.t -> t = "rust_expr_naive_datetime"
+val null : unit -> t
+val int : int -> t
+val float : float -> t
+val bool : bool -> t
+val string : string -> t
+val naive_date : Common.Naive_date.t -> t
+val naive_datetime : Common.Naive_datetime.t -> t
 val sort : ?descending:bool -> t -> t
 val sort_by : ?descending:bool -> t -> by:t list -> t
-external first : t -> t = "rust_expr_first"
-external last : t -> t = "rust_expr_last"
-external reverse : t -> t = "rust_expr_reverse"
+val first : t -> t
+val last : t -> t
+val reverse : t -> t
 val head : ?length:int -> t -> t
 val tail : ?length:int -> t -> t
 
@@ -32,17 +32,17 @@ val sample_n
   -> shuffle:bool
   -> t
 
-external filter : t -> predicate:t -> t = "rust_expr_filter"
-external sum : t -> t = "rust_expr_sum"
-external mean : t -> t = "rust_expr_mean"
-external median : t -> t = "rust_expr_median"
-external max : t -> t = "rust_expr_max"
-external min : t -> t = "rust_expr_min"
-external count : t -> t = "rust_expr_count"
-external count_ : unit -> t = "rust_expr_count_"
-external n_unique : t -> t = "rust_expr_n_unique"
-external approx_unique : t -> t = "rust_expr_approx_unique"
-external explode : t -> t = "rust_expr_explode"
+val filter : t -> predicate:t -> t
+val sum : t -> t
+val mean : t -> t
+val median : t -> t
+val max : t -> t
+val min : t -> t
+val count : t -> t
+val count_ : unit -> t
+val n_unique : t -> t
+val approx_unique : t -> t
+val explode : t -> t
 
 val over
   :  ?mapping_strategy:[ `Groups_to_rows | `Explode | `Join ]
@@ -51,19 +51,13 @@ val over
   -> t
 
 val concat_list : t Nonempty_list.t -> t
-external null_count : t -> t = "rust_expr_null_count"
-external is_null : t -> t = "rust_expr_is_null"
-external is_not_null : t -> t = "rust_expr_is_not_null"
-external fill_null : t -> with_:t -> t = "rust_expr_fill_null"
-
-external fill_null'
-  :  t
-  -> strategy:Fill_null_strategy.t
-  -> t
-  = "rust_expr_fill_null_with_strategy"
-
+val null_count : t -> t
+val is_null : t -> t
+val is_not_null : t -> t
+val fill_null : t -> with_:t -> t
+val fill_null' : t -> strategy:Fill_null_strategy.t -> t
 val interpolate : ?method_:[ `Linear | `Nearest ] -> t -> t
-external fill_nan : t -> with_:t -> t = "rust_expr_fill_nan"
+val fill_nan : t -> with_:t -> t
 
 val rank
   :  ?method_:[ `Average | `Dense | `Max | `Min | `Ordinal | `Random ]
@@ -72,18 +66,18 @@ val rank
   -> t
   -> t
 
-external when_ : (t * t) list -> otherwise:t -> t = "rust_expr_when_then"
+val when_ : (t * t) list -> otherwise:t -> t
 val shift : ?fill_value:t -> t -> periods:int -> t
 val cum_count : ?reverse:bool -> t -> t
 val cum_sum : ?reverse:bool -> t -> t
 val cum_prod : ?reverse:bool -> t -> t
 val cum_min : ?reverse:bool -> t -> t
 val cum_max : ?reverse:bool -> t -> t
-external alias : t -> name:string -> t = "rust_expr_alias"
-external prefix : t -> prefix:string -> t = "rust_expr_prefix"
-external suffix : t -> suffix:string -> t = "rust_expr_suffix"
+val alias : t -> name:string -> t
+val prefix : t -> prefix:string -> t
+val suffix : t -> suffix:string -> t
 val round : t -> decimals:int -> t
-external equal : t -> t -> t = "rust_expr_eq"
+val equal : t -> t -> t
 
 include Common.Compare with type t := t
 include Common.Logic with type t := t
@@ -94,39 +88,32 @@ val floor_div : t -> t -> t
 val ( // ) : t -> t -> t
 
 module Dt : sig
-  external strftime : t -> format:string -> t = "rust_expr_dt_strftime"
-  external convert_time_zone : t -> to_:string -> t = "rust_expr_dt_convert_time_zone"
-  external year : t -> t = "rust_expr_dt_year"
-  external month : t -> t = "rust_expr_dt_month"
-  external day : t -> t = "rust_expr_dt_day"
+  val strftime : t -> format:string -> t
+  val convert_time_zone : t -> to_:string -> t
+  val year : t -> t
+  val month : t -> t
+  val day : t -> t
 end
 
 module Str : sig
   val split : ?inclusive:bool -> t -> by:string -> t
-
-  external strptime
-    :  t
-    -> type_:Data_type.t
-    -> format:string
-    -> t
-    = "rust_expr_str_strptime"
-
-  external lengths : t -> t = "rust_expr_str_lengths"
-  external n_chars : t -> t = "rust_expr_str_n_chars"
+  val strptime : t -> type_:Data_type.t -> format:string -> t
+  val lengths : t -> t
+  val n_chars : t -> t
   val contains : ?literal:bool -> t -> pat:string -> t
-  external starts_with : t -> prefix:string -> t = "rust_expr_str_starts_with"
-  external ends_with : t -> suffix:string -> t = "rust_expr_str_ends_with"
+  val starts_with : t -> prefix:string -> t
+  val ends_with : t -> suffix:string -> t
   val extract : t -> pat:string -> group:int -> t
-  external extract_all : t -> pat:string -> t = "rust_expr_str_extract_all"
+  val extract_all : t -> pat:string -> t
   val replace : ?literal:bool -> t -> pat:string -> with_:string -> t
   val replace_all : ?literal:bool -> t -> pat:string -> with_:string -> t
 end
 
 module List : sig
-  external lengths : t -> t = "rust_expr_list_lengths"
-  external slice : t -> offset:t -> length:t -> t = "rust_expr_list_slice"
-  external head : t -> n:t -> t = "rust_expr_list_head"
-  external tail : t -> n:t -> t = "rust_expr_list_tail"
-  external sum : t -> t = "rust_expr_list_sum"
+  val lengths : t -> t
+  val slice : t -> offset:t -> length:t -> t
+  val head : t -> n:t -> t
+  val tail : t -> n:t -> t
+  val sum : t -> t
   val eval : ?parallel:bool -> t -> expr:t -> t
 end

--- a/lib/lazy_frame.mli
+++ b/lib/lazy_frame.mli
@@ -2,23 +2,18 @@ open! Core
 
 type t
 
-external scan_parquet : string -> (t, string) result = "rust_lazy_frame_scan_parquet"
+val scan_parquet : string -> (t, string) result
 val scan_parquet_exn : string -> t
-external scan_csv : string -> (t, string) result = "rust_lazy_frame_scan_csv"
+val scan_csv : string -> (t, string) result
 val scan_csv_exn : string -> t
-external to_dot : t -> (string, string) result = "rust_lazy_frame_to_dot"
-external collect : t -> (Data_frame0.t, string) result = "rust_lazy_frame_collect"
+val to_dot : t -> (string, string) result
+val collect : t -> (Data_frame0.t, string) result
 val collect_exn : t -> Data_frame0.t
-
-external collect_all
-  :  t list
-  -> (Data_frame0.t list, string) result
-  = "rust_lazy_frame_collect_all"
-
+val collect_all : t list -> (Data_frame0.t list, string) result
 val collect_all_exn : t list -> Data_frame0.t list
-external filter : t -> predicate:Expr.t -> t = "rust_lazy_frame_filter"
-external select : t -> exprs:Expr.t list -> t = "rust_lazy_frame_select"
-external with_columns : t -> exprs:Expr.t list -> t = "rust_lazy_frame_with_columns"
+val filter : t -> predicate:Expr.t -> t
+val select : t -> exprs:Expr.t list -> t
+val with_columns : t -> exprs:Expr.t list -> t
 val groupby : ?is_stable:bool -> t -> by:Expr.t list -> agg:Expr.t list -> t
 val join : t -> other:t -> on:Expr.t list -> how:Join_type.t -> t
 
@@ -48,7 +43,7 @@ val melt
 
 val sort : ?descending:bool -> ?nulls_last:bool -> t -> by_column:string -> t
 val limit : t -> n:int -> t
-external explode : t -> columns:Expr.t list -> t = "rust_lazy_frame_explode"
-external with_streaming : t -> toggle:bool -> t = "rust_lazy_frame_with_streaming"
-external schema : t -> (Schema.t, string) result = "rust_lazy_frame_schema"
+val explode : t -> columns:Expr.t list -> t
+val with_streaming : t -> toggle:bool -> t
+val schema : t -> (Schema.t, string) result
 val schema_exn : t -> Schema.t

--- a/lib/schema.mli
+++ b/lib/schema.mli
@@ -2,5 +2,5 @@ open! Core
 
 type t [@@deriving sexp]
 
-external create : (string * Data_type.t) list -> t = "rust_schema_create"
-external to_fields : t -> (string * Data_type.t) list = "rust_schema_to_fields"
+val create : (string * Data_type.t) list -> t
+val to_fields : t -> (string * Data_type.t) list

--- a/lib/series.mli
+++ b/lib/series.mli
@@ -2,20 +2,14 @@ open! Core
 
 type t
 
-external int : string -> int list -> t = "rust_series_new_int"
-external int_option : string -> int option list -> t = "rust_series_new_int_option"
-external float : string -> float list -> t = "rust_series_new_float"
-external float_option : string -> float option list -> t = "rust_series_new_float_option"
-external bool : string -> bool list -> t = "rust_series_new_bool"
-external bool_option : string -> bool option list -> t = "rust_series_new_bool_option"
-external string : string -> string list -> t = "rust_series_new_string"
-
-external string_option
-  :  string
-  -> string option list
-  -> t
-  = "rust_series_new_string_option"
-
+val int : string -> int list -> t
+val int_option : string -> int option list -> t
+val float : string -> float list -> t
+val float_option : string -> float option list -> t
+val bool : string -> bool list -> t
+val bool_option : string -> bool option list -> t
+val string : string -> string list -> t
+val string_option : string -> string option list -> t
 val date : string -> Date.t list -> t
 val datetime : string -> Common.Naive_datetime.t list -> t
 val datetime' : string -> Date.t list -> t
@@ -36,7 +30,7 @@ val sample_n
   -> (t, string) result
 
 val sample_n_exn : ?seed:int -> t -> n:int -> with_replacement:bool -> shuffle:bool -> t
-external to_string_hum : t -> string = "rust_series_to_string_hum"
+val to_string_hum : t -> string
 val print : t -> unit
 
 type typed_list =
@@ -47,7 +41,7 @@ type typed_list =
   | Bytes of bytes option list
 [@@deriving sexp_of]
 
-external to_typed_list : t -> (typed_list, string) result = "rust_series_to_typed_list"
+val to_typed_list : t -> (typed_list, string) result
 val to_typed_list_exn : t -> typed_list
 
 include Common.Compare with type t := t


### PR DESCRIPTION
Exposing `extern` in the mli apparently reduces call overhead of the functions, but I don't think this overhead is important for any use case of polars-ocaml, and makes the mli much more pleasant to read.