### PR TITLE
Reduce boilerplate with macros

### DIFF
--- a/rust/polars-ocaml/src/expr.rs
+++ b/rust/polars-ocaml/src/expr.rs
@@ -10,6 +10,12 @@ use polars_ocaml_macros::ocaml_interop_export;
 use crate::utils::PolarsDataType;
 use crate::utils::*;
 
+macro_rules! expr_op {
+    ($name:ident, |$($var:ident),+| $body:expr) => {
+        dyn_box_op!($name, Expr, |$($var),+| $body);
+    }
+}
+
 fn expr_series_map<'a>(
     cr: &'a mut &'a mut OCamlRuntime,
     expr: OCamlRef<'a, DynBox<Expr>>,
@@ -161,26 +167,9 @@ fn rust_expr_set_sorted_flag(
     dyn_box!(cr, |expr| expr.set_sorted_flag(is_sorted))
 }
 
-#[ocaml_interop_export]
-fn rust_expr_first(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.first())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_last(cr: &mut &mut OCamlRuntime, expr: OCamlRef<DynBox<Expr>>) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.last())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_reverse(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.reverse())
-}
+expr_op!(rust_expr_first, |expr| expr.first());
+expr_op!(rust_expr_last, |expr| expr.last());
+expr_op!(rust_expr_reverse, |expr| expr.reverse());
 
 // TODO: the following functions are ~roughly the same between Expr, Series,
 // and DataFrame; it would be nice if we could reduce the boilerplace around
@@ -215,14 +204,7 @@ fn rust_expr_tail(
     dyn_box!(cr, |expr| expr.tail(length))
 }
 
-#[ocaml_interop_export]
-fn rust_expr_take(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-    idx: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr, idx| expr.take(idx))
-}
+expr_op!(rust_expr_take, |expr, idx| expr.take(idx));
 
 #[ocaml_interop_export(raise_on_err)]
 fn rust_expr_sample_n(
@@ -251,27 +233,9 @@ fn rust_expr_sample_n(
     ))
 }
 
-#[ocaml_interop_export]
-fn rust_expr_filter(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-    predicate: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr, predicate| expr.filter(predicate))
-}
-
-#[ocaml_interop_export]
-fn rust_expr_ceil(cr: &mut &mut OCamlRuntime, expr: OCamlRef<DynBox<Expr>>) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.ceil())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_floor(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.floor())
-}
+expr_op!(rust_expr_filter, |expr, predicate| expr.filter(predicate));
+expr_op!(rust_expr_ceil, |expr| expr.ceil());
+expr_op!(rust_expr_floor, |expr| expr.floor());
 
 #[ocaml_interop_export]
 fn rust_expr_clip_min_float(
@@ -313,66 +277,15 @@ fn rust_expr_clip_max_int(
     dyn_box!(cr, |expr| expr.clip_max(AnyValue::Int64(max)))
 }
 
-#[ocaml_interop_export]
-fn rust_expr_pow(
-    cr: &mut &mut OCamlRuntime,
-    base: OCamlRef<DynBox<Expr>>,
-    exponent: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |base, exponent| base.pow(exponent))
-}
-
-#[ocaml_interop_export]
-fn rust_expr_sum(cr: &mut &mut OCamlRuntime, expr: OCamlRef<DynBox<Expr>>) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.sum())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_mean(cr: &mut &mut OCamlRuntime, expr: OCamlRef<DynBox<Expr>>) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.mean())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_median(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.median())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_max(cr: &mut &mut OCamlRuntime, expr: OCamlRef<DynBox<Expr>>) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.max())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_min(cr: &mut &mut OCamlRuntime, expr: OCamlRef<DynBox<Expr>>) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.min())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_arg_max(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.arg_max())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_arg_min(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.arg_min())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_count(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.count())
-}
+expr_op!(rust_expr_pow, |base, exponent| base.pow(exponent));
+expr_op!(rust_expr_sum, |expr| expr.sum());
+expr_op!(rust_expr_mean, |expr| expr.mean());
+expr_op!(rust_expr_median, |expr| expr.median());
+expr_op!(rust_expr_max, |expr| expr.max());
+expr_op!(rust_expr_min, |expr| expr.min());
+expr_op!(rust_expr_arg_max, |expr| expr.arg_max());
+expr_op!(rust_expr_arg_min, |expr| expr.arg_min());
+expr_op!(rust_expr_count, |expr| expr.count());
 
 #[ocaml_interop_export]
 fn rust_expr_count_(cr: &mut &mut OCamlRuntime, unit: OCamlRef<()>) -> OCaml<DynBox<Expr>> {
@@ -380,29 +293,9 @@ fn rust_expr_count_(cr: &mut &mut OCamlRuntime, unit: OCamlRef<()>) -> OCaml<Dyn
     OCaml::box_value(cr, count())
 }
 
-#[ocaml_interop_export]
-fn rust_expr_n_unique(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.n_unique())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_approx_unique(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.approx_unique())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_explode(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.explode())
-}
+expr_op!(rust_expr_n_unique, |expr| expr.n_unique());
+expr_op!(rust_expr_approx_unique, |expr| expr.approx_unique());
+expr_op!(rust_expr_explode, |expr| expr.explode());
 
 #[ocaml_interop_export]
 fn rust_expr_over(
@@ -435,54 +328,13 @@ fn rust_expr_concat_list(
         .to_ocaml(cr)
 }
 
-#[ocaml_interop_export]
-fn rust_expr_null_count(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.null_count())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_is_null(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.is_null())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_is_not_null(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.is_not_null())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_is_nan(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.is_nan())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_is_not_nan(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.is_not_nan())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_fill_null(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-    with: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr, with| expr.fill_null(with))
-}
+expr_op!(rust_expr_null_count, |expr| expr.null_count());
+expr_op!(rust_expr_is_null, |expr| expr.is_null());
+expr_op!(rust_expr_is_not_null, |expr| expr.is_not_null());
+expr_op!(rust_expr_is_nan, |expr| expr.is_nan());
+expr_op!(rust_expr_is_not_nan, |expr| expr.is_not_nan());
+expr_op!(rust_expr_fill_null, |expr, with| expr.fill_null(with));
+expr_op!(rust_expr_fill_nan, |expr, with| expr.fill_nan(with));
 
 #[ocaml_interop_export]
 fn rust_expr_fill_null_with_strategy(
@@ -507,15 +359,6 @@ fn rust_expr_interpolate(
 ) -> OCaml<DynBox<Expr>> {
     let PolarsInterpolationMethod(method) = method.to_rust(cr);
     dyn_box!(cr, |expr| expr.interpolate(method))
-}
-
-#[ocaml_interop_export]
-fn rust_expr_fill_nan(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-    with: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr, with| expr.fill_nan(with))
 }
 
 #[ocaml_interop_export(raise_on_err)]
@@ -683,136 +526,21 @@ fn rust_expr_round(
     dyn_box!(cr, |expr| expr.round(decimals))
 }
 
-#[ocaml_interop_export]
-fn rust_expr_eq(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-    other: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr, other| expr.eq(other))
-}
-
-#[ocaml_interop_export]
-fn rust_expr_neq(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-    other: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr, other| expr.neq(other))
-}
-
-#[ocaml_interop_export]
-fn rust_expr_gt(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-    other: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr, other| expr.gt(other))
-}
-
-#[ocaml_interop_export]
-fn rust_expr_gt_eq(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-    other: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr, other| expr.gt_eq(other))
-}
-
-#[ocaml_interop_export]
-fn rust_expr_lt(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-    other: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr, other| expr.lt(other))
-}
-
-#[ocaml_interop_export]
-fn rust_expr_lt_eq(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-    other: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr, other| expr.lt_eq(other))
-}
-
-#[ocaml_interop_export]
-fn rust_expr_not(cr: &mut &mut OCamlRuntime, expr: OCamlRef<DynBox<Expr>>) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.not())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_and(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-    other: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr, other| expr.and(other))
-}
-
-#[ocaml_interop_export]
-fn rust_expr_or(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-    other: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr, other| expr.or(other))
-}
-
-#[ocaml_interop_export]
-fn rust_expr_xor(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-    other: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr, other| expr.xor(other))
-}
-
-#[ocaml_interop_export]
-fn rust_expr_add(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-    other: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr, other| expr + other)
-}
-
-#[ocaml_interop_export]
-fn rust_expr_sub(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-    other: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr, other| expr - other)
-}
-
-#[ocaml_interop_export]
-fn rust_expr_mul(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-    other: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr, other| expr * other)
-}
-
-#[ocaml_interop_export]
-fn rust_expr_div(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-    other: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr, other| expr / other)
-}
-
-#[ocaml_interop_export]
-fn rust_expr_floor_div(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-    other: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr, other| expr.floor_div(other))
-}
+expr_op!(rust_expr_eq, |expr, other| expr.eq(other));
+expr_op!(rust_expr_neq, |expr, other| expr.neq(other));
+expr_op!(rust_expr_gt, |expr, other| expr.gt(other));
+expr_op!(rust_expr_gt_eq, |expr, other| expr.gt_eq(other));
+expr_op!(rust_expr_lt, |expr, other| expr.lt(other));
+expr_op!(rust_expr_lt_eq, |expr, other| expr.lt_eq(other));
+expr_op!(rust_expr_not, |expr| expr.not());
+expr_op!(rust_expr_and, |expr, other| expr.and(other));
+expr_op!(rust_expr_or, |expr, other| expr.or(other));
+expr_op!(rust_expr_xor, |expr, other| expr.xor(other));
+expr_op!(rust_expr_add, |expr, other| expr + other);
+expr_op!(rust_expr_sub, |expr, other| expr - other);
+expr_op!(rust_expr_mul, |expr, other| expr * other);
+expr_op!(rust_expr_div, |expr, other| expr / other);
+expr_op!(rust_expr_floor_div, |expr, other| expr.floor_div(other));
 
 #[ocaml_interop_export]
 fn rust_expr_dt_strftime(
@@ -848,29 +576,9 @@ fn rust_expr_dt_replace_time_zone(
     })
 }
 
-#[ocaml_interop_export]
-fn rust_expr_dt_year(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.dt().year())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_dt_month(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.dt().month())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_dt_day(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.dt().day())
-}
+expr_op!(rust_expr_dt_year, |expr| expr.dt().year());
+expr_op!(rust_expr_dt_month, |expr| expr.dt().month());
+expr_op!(rust_expr_dt_day, |expr| expr.dt().day());
 
 #[ocaml_interop_export]
 fn rust_expr_dt_days(
@@ -1202,21 +910,8 @@ fn rust_expr_str_rstrip(
     dyn_box!(cr, |expr| expr.str().rstrip(matches))
 }
 
-#[ocaml_interop_export]
-fn rust_expr_str_to_lowercase(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.str().to_lowercase())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_str_to_uppercase(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.str().to_uppercase())
-}
+expr_op!(rust_expr_str_to_lowercase, |expr| expr.str().to_lowercase());
+expr_op!(rust_expr_str_to_uppercase, |expr| expr.str().to_uppercase());
 
 #[ocaml_interop_export(raise_on_err)]
 fn rust_expr_str_slice(
@@ -1232,51 +927,13 @@ fn rust_expr_str_slice(
     dyn_box!(cr, |expr| expr.str().str_slice(start, length))
 }
 
-#[ocaml_interop_export]
-fn rust_expr_list_lengths(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.list().lengths())
-}
-
-#[ocaml_interop_export]
-fn rust_expr_list_slice(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-    offset: OCamlRef<DynBox<Expr>>,
-    length: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr, offset, length| {
-        expr.list().slice(offset, length)
-    })
-}
-
-#[ocaml_interop_export]
-fn rust_expr_list_head(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-    n: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr, n| expr.list().head(n))
-}
-
-#[ocaml_interop_export]
-fn rust_expr_list_tail(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-    n: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr, n| expr.list().tail(n))
-}
-
-#[ocaml_interop_export]
-fn rust_expr_list_sum(
-    cr: &mut &mut OCamlRuntime,
-    expr: OCamlRef<DynBox<Expr>>,
-) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| expr.list().sum())
-}
+expr_op!(rust_expr_list_lengths, |expr| expr.list().lengths());
+expr_op!(rust_expr_list_slice, |expr, offset, length| {
+    expr.list().slice(offset, length)
+});
+expr_op!(rust_expr_list_head, |expr, n| expr.list().head(n));
+expr_op!(rust_expr_list_tail, |expr, n| expr.list().tail(n));
+expr_op!(rust_expr_list_sum, |expr| expr.list().sum());
 
 #[ocaml_interop_export]
 fn rust_expr_list_eval(

--- a/rust/polars-ocaml/src/series.rs
+++ b/rust/polars-ocaml/src/series.rs
@@ -8,35 +8,6 @@ use polars::prelude::prelude::*;
 use polars::prelude::*;
 use polars_ocaml_macros::ocaml_interop_export;
 
-// TODO: These helper fuctions should be replaced by a macro.
-fn series_binary_op<'a>(
-    cr: &'a mut &'a mut OCamlRuntime,
-    series: OCamlRef<'a, DynBox<Series>>,
-    other: OCamlRef<'a, DynBox<Series>>,
-    f: impl Fn(Series, Series) -> Series,
-) -> OCaml<'a, DynBox<Series>> {
-    let Abstract(series) = series.to_rust(cr);
-    let Abstract(other) = other.to_rust(cr);
-
-    OCaml::box_value(cr, f(series, other))
-}
-
-fn series_binary_op_result<'a>(
-    cr: &'a mut &'a mut OCamlRuntime,
-    series: OCamlRef<'a, DynBox<Series>>,
-    other: OCamlRef<'a, DynBox<Series>>,
-    f: impl Fn(Series, Series) -> Result<Series, PolarsError>,
-) -> OCaml<'a, Result<DynBox<Series>, String>> {
-    let Abstract(series) = series.to_rust(cr);
-    let Abstract(other) = other.to_rust(cr);
-
-    let series = f(series, other)
-        .map(Abstract)
-        .map_err(|err| err.to_string());
-
-    series.to_ocaml(cr)
-}
-
 // The rough idea of functions which take GADTDataType is that the argument or
 // the return type depends on the value of the GADTDataType, so we hide the
 // actual type of the argument or return value behind a DummyBoxRoot and
@@ -625,8 +596,7 @@ fn rust_series_to_data_frame(
     cr: &mut &mut OCamlRuntime,
     series: OCamlRef<DynBox<Series>>,
 ) -> OCaml<DynBox<DataFrame>> {
-    let Abstract(series) = series.to_rust(cr);
-    OCaml::box_value(cr, series.into_frame())
+    dyn_box!(cr, |series| series.into_frame())
 }
 
 #[ocaml_interop_export]
@@ -635,10 +605,9 @@ fn rust_series_sort(
     series: OCamlRef<DynBox<Series>>,
     descending: OCamlRef<bool>,
 ) -> OCaml<DynBox<Series>> {
-    let Abstract(series) = series.to_rust(cr);
     let descending: bool = descending.to_rust(cr);
 
-    OCaml::box_value(cr, series.sort(descending))
+    dyn_box!(cr, |series| series.sort(descending))
 }
 
 #[ocaml_interop_export(raise_on_err)]
@@ -647,12 +616,11 @@ fn rust_series_head(
     series: OCamlRef<DynBox<Series>>,
     length: OCamlRef<Option<OCamlInt>>,
 ) -> OCaml<DynBox<Series>> {
-    let Abstract(series) = series.to_rust(cr);
     let length = length
         .to_rust::<Coerce<_, Option<i64>, Option<usize>>>(cr)
         .get()?;
 
-    Abstract(series.head(length)).to_ocaml(cr)
+    dyn_box!(cr, |series| series.head(length))
 }
 
 #[ocaml_interop_export(raise_on_err)]
@@ -661,12 +629,11 @@ fn rust_series_tail(
     series: OCamlRef<DynBox<Series>>,
     length: OCamlRef<Option<OCamlInt>>,
 ) -> OCaml<DynBox<Series>> {
-    let Abstract(series) = series.to_rust(cr);
     let length = length
         .to_rust::<Coerce<_, Option<i64>, Option<usize>>>(cr)
         .get()?;
 
-    Abstract(series.tail(length)).to_ocaml(cr)
+    dyn_box!(cr, |series| series.tail(length))
 }
 
 #[ocaml_interop_export(raise_on_err)]
@@ -678,7 +645,6 @@ fn rust_series_sample_n(
     shuffle: OCamlRef<bool>,
     seed: OCamlRef<Option<OCamlInt>>,
 ) -> OCaml<Result<DynBox<Series>, String>> {
-    let Abstract(series) = series.to_rust(cr);
     let n = n.to_rust::<Coerce<_, i64, usize>>(cr).get()?;
     let with_replacement: bool = with_replacement.to_rust(cr);
     let shuffle: bool = shuffle.to_rust(cr);
@@ -686,11 +652,9 @@ fn rust_series_sample_n(
         .to_rust::<Coerce<_, Option<i64>, Option<u64>>>(cr)
         .get()?;
 
-    series
-        .sample_n(n, with_replacement, shuffle, seed)
-        .map(Abstract)
-        .map_err(|err| err.to_string())
-        .to_ocaml(cr)
+    dyn_box_result!(cr, |series| {
+        series.sample_n(n, with_replacement, shuffle, seed)
+    })
 }
 
 #[ocaml_interop_export]
@@ -699,14 +663,9 @@ fn rust_series_fill_null_with_strategy(
     series: OCamlRef<DynBox<Series>>,
     strategy: OCamlRef<FillNullStrategy>,
 ) -> OCaml<Result<DynBox<Series>, String>> {
-    let Abstract(series) = series.to_rust(cr);
     let PolarsFillNullStrategy(strategy) = strategy.to_rust(cr);
 
-    series
-        .fill_null(strategy)
-        .map(Abstract)
-        .map_err(|err| err.to_string())
-        .to_ocaml(cr)
+    dyn_box_result!(cr, |series| series.fill_null(strategy))
 }
 
 #[ocaml_interop_export]
@@ -715,113 +674,46 @@ fn rust_series_interpolate(
     series: OCamlRef<DynBox<Series>>,
     method: OCamlRef<InterpolationMethod>,
 ) -> OCaml<DynBox<Series>> {
-    let Abstract(series) = series.to_rust(cr);
     let PolarsInterpolationMethod(method) = method.to_rust(cr);
 
-    Abstract(interpolate(&series, method)).to_ocaml(cr)
+    dyn_box!(cr, |series| interpolate(&series, method))
 }
 
-#[ocaml_interop_export]
-fn rust_series_eq(
-    cr: &mut &mut OCamlRuntime,
-    series: OCamlRef<DynBox<Series>>,
-    other: OCamlRef<DynBox<Series>>,
-) -> OCaml<Result<DynBox<Series>, String>> {
-    series_binary_op_result(cr, series, other, |a, b| {
-        a.equal(&b).map(|series| series.into_series())
-    })
+macro_rules! series_op {
+    ($name:ident, |$($var:ident),+| $body:expr) => {
+        dyn_box_op!($name, Series, |$($var),+| $body);
+    }
 }
 
-#[ocaml_interop_export]
-fn rust_series_neq(
-    cr: &mut &mut OCamlRuntime,
-    series: OCamlRef<DynBox<Series>>,
-    other: OCamlRef<DynBox<Series>>,
-) -> OCaml<Result<DynBox<Series>, String>> {
-    series_binary_op_result(cr, series, other, |a, b| {
-        a.not_equal(&b).map(|series| series.into_series())
-    })
+macro_rules! series_op_result {
+    ($name:ident, |$($var:ident),+| $body:expr) => {
+        dyn_box_op_result!($name, Series, |$($var),+| $body);
+    }
 }
 
-#[ocaml_interop_export]
-fn rust_series_gt(
-    cr: &mut &mut OCamlRuntime,
-    series: OCamlRef<DynBox<Series>>,
-    other: OCamlRef<DynBox<Series>>,
-) -> OCaml<Result<DynBox<Series>, String>> {
-    series_binary_op_result(cr, series, other, |a, b| {
-        a.gt(&b).map(|series| series.into_series())
-    })
-}
+series_op_result!(rust_series_eq, |series, other| {
+    series.equal(&other).map(|series| series.into_series())
+});
+series_op_result!(rust_series_neq, |series, other| {
+    series.not_equal(&other).map(|series| series.into_series())
+});
+series_op_result!(rust_series_gt, |series, other| {
+    series.gt(&other).map(|series| series.into_series())
+});
+series_op_result!(rust_series_gt_eq, |series, other| {
+    series.gt_eq(&other).map(|series| series.into_series())
+});
+series_op_result!(rust_series_lt, |series, other| {
+    series.lt(&other).map(|series| series.into_series())
+});
+series_op_result!(rust_series_lt_eq, |series, other| {
+    series.lt_eq(&other).map(|series| series.into_series())
+});
 
-#[ocaml_interop_export]
-fn rust_series_gt_eq(
-    cr: &mut &mut OCamlRuntime,
-    series: OCamlRef<DynBox<Series>>,
-    other: OCamlRef<DynBox<Series>>,
-) -> OCaml<Result<DynBox<Series>, String>> {
-    series_binary_op_result(cr, series, other, |a, b| {
-        a.gt_eq(&b).map(|series| series.into_series())
-    })
-}
-
-#[ocaml_interop_export]
-fn rust_series_lt(
-    cr: &mut &mut OCamlRuntime,
-    series: OCamlRef<DynBox<Series>>,
-    other: OCamlRef<DynBox<Series>>,
-) -> OCaml<Result<DynBox<Series>, String>> {
-    series_binary_op_result(cr, series, other, |a, b| {
-        a.lt(&b).map(|series| series.into_series())
-    })
-}
-
-#[ocaml_interop_export]
-fn rust_series_lt_eq(
-    cr: &mut &mut OCamlRuntime,
-    series: OCamlRef<DynBox<Series>>,
-    other: OCamlRef<DynBox<Series>>,
-) -> OCaml<Result<DynBox<Series>, String>> {
-    series_binary_op_result(cr, series, other, |a, b| {
-        a.lt_eq(&b).map(|series| series.into_series())
-    })
-}
-
-#[ocaml_interop_export]
-fn rust_series_add(
-    cr: &mut &mut OCamlRuntime,
-    series: OCamlRef<DynBox<Series>>,
-    other: OCamlRef<DynBox<Series>>,
-) -> OCaml<DynBox<Series>> {
-    series_binary_op(cr, series, other, |a, b| a + b)
-}
-
-#[ocaml_interop_export]
-fn rust_series_sub(
-    cr: &mut &mut OCamlRuntime,
-    series: OCamlRef<DynBox<Series>>,
-    other: OCamlRef<DynBox<Series>>,
-) -> OCaml<DynBox<Series>> {
-    series_binary_op(cr, series, other, |a, b| a - b)
-}
-
-#[ocaml_interop_export]
-fn rust_series_mul(
-    cr: &mut &mut OCamlRuntime,
-    series: OCamlRef<DynBox<Series>>,
-    other: OCamlRef<DynBox<Series>>,
-) -> OCaml<DynBox<Series>> {
-    series_binary_op(cr, series, other, |a, b| a * b)
-}
-
-#[ocaml_interop_export]
-fn rust_series_div(
-    cr: &mut &mut OCamlRuntime,
-    series: OCamlRef<DynBox<Series>>,
-    other: OCamlRef<DynBox<Series>>,
-) -> OCaml<DynBox<Series>> {
-    series_binary_op(cr, series, other, |a, b| a / b)
-}
+series_op!(rust_series_add, |series, other| series + other);
+series_op!(rust_series_sub, |series, other| series - other);
+series_op!(rust_series_mul, |series, other| series * other);
+series_op!(rust_series_div, |series, other| series / other);
 
 #[ocaml_interop_export]
 fn rust_series_to_string_hum(

--- a/rust/polars-ocaml/src/sql_context.rs
+++ b/rust/polars-ocaml/src/sql_context.rs
@@ -63,13 +63,10 @@ fn rust_sql_context_execute(
     sql_context: OCamlRef<DynBox<PolarsSQLContext>>,
     query: OCamlRef<String>,
 ) -> OCaml<Result<DynBox<LazyFrame>, String>> {
-    let Abstract(sql_context) = sql_context.to_rust(cr);
     let query: String = query.to_rust(cr);
 
-    let result = sql_context.borrow_mut().execute(&query);
-
-    result
-        .map(Abstract)
-        .map_err(|err| err.to_string())
-        .to_ocaml(cr)
+    dyn_box_result!(cr, |sql_context| {
+        let result = sql_context.borrow_mut().execute(&query);
+        result
+    })
 }


### PR DESCRIPTION
A lot of the pain associated with writing bindings is writing out a ton of boilerplate. This PR introduces a couple of macros which makes it easier to write functions which interact with values of type `DynBox<_>`.