### PR TITLE
Add support for passing `Time_ns.t`s

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -90,8 +90,8 @@ jobs:
 
       - run: opam install . --deps-only --with-doc --with-test
 
-      - run: opam exec -- dune build
-      - run: opam exec -- dune runtest
+      - run: opam exec -- dune build --profile release
+      - run: opam exec -- dune runtest --profile release
 
   format-ocaml:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,6 +93,8 @@ jobs:
 
       - run: opam install . --deps-only --with-doc --with-test
 
+      - run: sed -i "s/cargo build/cargo build --target $CARGO_BUILD_TARGET/" lib/dune
+      - run: sed -i 's/rust\/target/rust\/target\/'"$CARGO_BUILD_TARGET"'/' lib/dune
       - run: opam exec -- dune build --profile release
       - run: opam exec -- dune runtest --profile release
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,12 +76,6 @@ jobs:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
 
-      - name: OCaml/opam cache
-        id: polars-ocaml-opam-cache
-        uses: actions/cache@v3
-        with:
-          path: "~/.opam"
-          key: polars-ocaml-opam-${{ matrix.ocaml-compiler }}-ubuntu-latest
       - name: Setup OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,6 +61,12 @@ jobs:
         working-directory: ./rust
 
   build-ocaml:
+    strategy:
+      fail-fast: false
+      matrix:
+        ocaml-compiler:
+          - 4.14.x
+          - 4.14.x+32bit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -75,10 +81,11 @@ jobs:
         uses: actions/cache@v3
         with:
           path: "~/.opam"
-          key: polars-ocaml-opam-4.14.x-ubuntu-latest
-      - uses: ocaml/setup-ocaml@v2
+          key: polars-ocaml-opam-${{ matrix.ocaml-compiler }}-ubuntu-latest
+      - name: Setup OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-compiler: 4.14.x
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
       - name: Set opam env
         run: opam env | tr '\n' ' ' >> $GITHUB_ENV
       - name: Add opam switch to PATH

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,11 +68,14 @@ jobs:
           - 4.14.1
           - ocaml-variants.4.14.1+options,ocaml-option-32bit
     runs-on: ubuntu-latest
+    env:
+      CARGO_BUILD_TARGET: ${{ matrix.ocaml-compiler == '4.14.1' && 'x86_64-unknown-linux-gnu' || 'i686-unknown-linux-gnu' }}
     steps:
       - uses: actions/checkout@v3
 
       - uses: dtolnay/rust-toolchain@nightly
         with:
+          targets: ${{ env.CARGO_BUILD_TARGET }}
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,6 @@ jobs:
       - name: Add opam switch to PATH
         run: opam var bin >> $GITHUB_PATH
 
-      - uses: rui314/setup-mold@v1
       - run: rm ./rust/.cargo/config.toml
       - run: sed -i '/.*mold.*/d' test/dune guide/dune
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,22 +60,25 @@ jobs:
         run: cargo fmt --all -- --check
         working-directory: ./rust
 
+  # In the past we tried to support building this on 32bit architectures, but
+  # some of polars' crates clearly don't support it[1] and getting both the
+  # OCaml and Rust compilers to work on 32bit is a pain, so we are leaving
+  # this comment as a reminder so that we do not try this without sufficient
+  # motivation again.
+  #
+  # [1]: https://github.com/pola-rs/polars/blob/c4fdbfe2c7f7ce7616ad9301981bc5d616c3beef/crates/polars-row/src/row.rs#L21
   build-ocaml:
     strategy:
       fail-fast: false
       matrix:
         ocaml-compiler:
           - 4.14.1
-          - ocaml-variants.4.14.1+options,ocaml-option-32bit
     runs-on: ubuntu-latest
-    env:
-      CARGO_BUILD_TARGET: ${{ matrix.ocaml-compiler == '4.14.1' && 'x86_64-unknown-linux-gnu' || 'i686-unknown-linux-gnu' }}
     steps:
       - uses: actions/checkout@v3
 
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          targets: ${{ env.CARGO_BUILD_TARGET }}
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
 
@@ -93,10 +96,8 @@ jobs:
 
       - run: opam install . --deps-only --with-doc --with-test
 
-      - run: sed -i "s/cargo build/cargo build --target $CARGO_BUILD_TARGET/" lib/dune
-      - run: sed -i 's/rust\/target/rust\/target\/'"$CARGO_BUILD_TARGET"'/' lib/dune
-      - run: opam exec -- dune build --profile release
-      - run: opam exec -- dune runtest --profile release
+      - run: opam exec -- dune build
+      - run: opam exec -- dune runtest
 
   format-ocaml:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,7 +87,7 @@ jobs:
 
       - uses: rui314/setup-mold@v1
       - run: rm ./rust/.cargo/config.toml
-      - run: sed -i '/.*mold.*/d' test/dune
+      - run: sed -i '/.*mold.*/d' test/dune guide/dune
 
       - run: opam install . --deps-only --with-doc --with-test
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,8 +65,8 @@ jobs:
       fail-fast: false
       matrix:
         ocaml-compiler:
-          - 4.14.x
-          - 4.14.x+32bit
+          - 4.14.1
+          - ocaml-variants.4.14.1+options,ocaml-option-32bit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,7 +93,7 @@ jobs:
         run: opam var bin >> $GITHUB_PATH
 
       - run: rm ./rust/.cargo/config.toml
-      - run: sed -i '/.*mold.*/d' test/dune guide/dune
+      - run: sed -i '/.*mold.*/d' lib/dune test/dune guide/dune
 
       - run: opam install . --deps-only --with-doc --with-test
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,13 +60,14 @@ jobs:
         run: cargo fmt --all -- --check
         working-directory: ./rust
 
-  # In the past we tried to support building this on 32bit architectures, but
-  # some of polars' crates clearly don't support it[1] and getting both the
+  # In the past we tried to support building this on 32bit architectures,[1] but
+  # some of polars' crates clearly don't support it[2] and getting both the
   # OCaml and Rust compilers to work on 32bit is a pain, so we are leaving
   # this comment as a reminder so that we do not try this without sufficient
   # motivation again.
   #
-  # [1]: https://github.com/pola-rs/polars/blob/c4fdbfe2c7f7ce7616ad9301981bc5d616c3beef/crates/polars-row/src/row.rs#L21
+  # [1]: https://github.com/mt-caret/polars-ocaml/pull/64
+  # [2]: https://github.com/pola-rs/polars/blob/c4fdbfe2c7f7ce7616ad9301981bc5d616c3beef/crates/polars-row/src/row.rs#L21
   build-ocaml:
     strategy:
       fail-fast: false

--- a/HACKING.md
+++ b/HACKING.md
@@ -5,13 +5,3 @@ $ opam switch create 4.14.1
 $ opam install . --deps-only --with-doc --with-test
 $ dune build @fmt @runtest @doc -w --auto-promote
 ```
-
-# Building a 32bit binary
-
-```
-$ rustup target add i686-unknown-linux-gnu
-$ opam switch create 4.14.1+32bit ocaml-variants.4.14.1+options ocaml-option-32bit
-$ sed -i "s/cargo build/cargo build --target i686-unknown-linux-gnu/" lib/dune
-$ sed -i 's/rust\/target/rust\/target\/i686-unknown-linux-gnu/' lib/dune
-$ dune build @fmt @runtest @doc -w --auto-promote
-```

--- a/HACKING.md
+++ b/HACKING.md
@@ -2,6 +2,7 @@
 
 ```
 $ opam switch create 4.14.1
+$ opam install dune ocamlformat
 $ opam install . --deps-only --with-doc --with-test
 $ dune build @fmt @runtest @doc -w --auto-promote
 ```

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,17 @@
+# Recommended development setup
+
+```
+$ opam switch create 4.14.1
+$ opam install . --deps-only --with-doc --with-test
+$ dune build @fmt @runtest @doc -w --auto-promote
+```
+
+# Building a 32bit binary
+
+```
+$ rustup target add i686-unknown-linux-gnu
+$ opam switch create 4.14.1+32bit ocaml-variants.4.14.1+options ocaml-option-32bit
+$ sed -i "s/cargo build/cargo build --target i686-unknown-linux-gnu/" lib/dune
+$ sed -i 's/rust\/target/rust\/target\/i686-unknown-linux-gnu/' lib/dune
+$ dune build @fmt @runtest @doc -w --auto-promote
+```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ can do with polars-ocaml!
 
 Currently very much WIP. Please expect breakages and large changes in API.
 
-Note that the current code assumes that the OCaml version is 4.14.1.
+Note that the current code assumes that the OCaml version is 4.14.1;
+see [HACKING.md](./HACKING.md) for notes on how to build polars-ocaml.
 
 ## utop
 

--- a/bin/dune
+++ b/bin/dune
@@ -2,4 +2,4 @@
  (package polars)
  (public_name polars)
  (name main)
- (libraries polars))
+ (libraries polars core core_unix.time_ns_unix))

--- a/bin/dune
+++ b/bin/dune
@@ -2,4 +2,4 @@
  (package polars)
  (public_name polars)
  (name main)
- (libraries polars core core_unix.time_ns_unix))
+ (libraries polars))

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -89,6 +89,24 @@ module Naive_datetime = struct
     parse_and_print "2023-01-02 03";
     [%expect {| 2023-01-02 03:00:00 |}]
   ;;
+
+  external of_time_ns : Time_ns.t -> t option = "rust_time_ns_to_naive_datetime"
+
+  let of_time_ns_exn time_ns =
+    of_time_ns time_ns
+    |> Option.value_or_thunk ~default:(fun () ->
+      raise_s [%message "Invalid time" (time_ns : Time_ns_unix.t)])
+  ;;
+
+  let%expect_test "of_time_ns" =
+    let time_ns = Time_ns_unix.of_string "2023-01-02 03:04:05.678" in
+    of_time_ns_exn time_ns |> to_string |> print_endline;
+    [%expect {| 2023-01-02 03:04:05.678 |}]
+  ;;
+
+  external to_timestamp_nanos : t -> int = "rust_naive_datetime_to_timestamp_nanos"
+
+  let to_time_ns t = to_timestamp_nanos t |> Time_ns.of_int_ns_since_epoch
 end
 
 external record_panic_backtraces : unit -> unit = "rust_record_panic_backtraces"

--- a/lib/common_intf.ml
+++ b/lib/common_intf.ml
@@ -68,7 +68,11 @@ module type Common = sig
 
     val of_naive_date : ?hour:int -> ?min:int -> ?sec:int -> Naive_date.t -> t
     val of_date : ?hour:int -> ?min:int -> ?sec:int -> Date.t -> t
+    val to_string : t -> string
     val of_string : string -> t
+    val of_time_ns : Time_ns.t -> t option
+    val of_time_ns_exn : Time_ns.t -> t
+    val to_time_ns : t -> Time_ns.t
   end
 
   val record_panic_backtraces : unit -> unit

--- a/lib/dune
+++ b/lib/dune
@@ -33,7 +33,7 @@
  (name polars)
  (public_name polars)
  (foreign_archives polars_ocaml)
- (libraries core core_kernel.nonempty_list)
+ (libraries core core_kernel.nonempty_list core_unix.time_ns_unix)
  (inline_tests)
  (preprocess
   (pps ppx_jane)))

--- a/lib/dune
+++ b/lib/dune
@@ -1,22 +1,36 @@
 (rule
  (targets libpolars_ocaml.a dllpolars_ocaml.so)
+ (enabled_if
+  (= %{profile} release))
  (deps
   (glob_files ../rust/Cargo.*)
   (glob_files ../rust/polars-ocaml/Cargo.*)
   (glob_files ../rust/polars-ocaml/src/*.rs)
   (glob_files ../rust/polars-ocaml-macros/Cargo.*)
   (glob_files ../rust/polars-ocaml-macros/src/*.rs))
- ;(action
- ; (progn
- ;  (run sh -c "cd %{project_root}/rust && cargo build --release")
- ;  (run
- ;   sh
- ;   -c
- ;   "cp %{project_root}/rust/target/release/libpolars_ocaml.so ./dllpolars_ocaml.so 2> /dev/null || cp %{project_root}/rust/target/release/libpolars_ocaml.dylib ./dllpolars_ocaml.so")
- ;  (run
- ;   cp
- ;   %{project_root}/rust/target/release/libpolars_ocaml.a
- ;   libpolars_ocaml.a)))
+ (action
+  (progn
+   (run sh -c "cd %{project_root}/rust && cargo build --release")
+   (run
+    sh
+    -c
+    "cp %{project_root}/rust/target/release/libpolars_ocaml.so ./dllpolars_ocaml.so 2> /dev/null || cp %{project_root}/rust/target/release/libpolars_ocaml.dylib ./dllpolars_ocaml.so")
+   (run
+    cp
+    %{project_root}/rust/target/release/libpolars_ocaml.a
+    libpolars_ocaml.a))))
+
+(rule
+ (targets libpolars_ocaml.a dllpolars_ocaml.so)
+ (enabled_if
+  (not
+   (= %{profile} release)))
+ (deps
+  (glob_files ../rust/Cargo.*)
+  (glob_files ../rust/polars-ocaml/Cargo.*)
+  (glob_files ../rust/polars-ocaml/src/*.rs)
+  (glob_files ../rust/polars-ocaml-macros/Cargo.*)
+  (glob_files ../rust/polars-ocaml-macros/src/*.rs))
  (action
   (progn
    (run sh -c "cd %{project_root}/rust && cargo build")

--- a/lib/expr.ml
+++ b/lib/expr.ml
@@ -21,6 +21,9 @@ module T = struct
   external string : string -> t = "rust_expr_string"
   external naive_date : Common.Naive_date.t -> t = "rust_expr_naive_date"
   external naive_datetime : Common.Naive_datetime.t -> t = "rust_expr_naive_datetime"
+
+  let time time = naive_datetime (Common.Naive_datetime.of_time_ns_exn time)
+
   external series : Series.t -> t = "rust_expr_series"
   external sort : t -> descending:bool -> t = "rust_expr_sort"
 

--- a/lib/expr.mli
+++ b/lib/expr.mli
@@ -15,6 +15,7 @@ val bool : bool -> t
 val string : string -> t
 val naive_date : Common.Naive_date.t -> t
 val naive_datetime : Common.Naive_datetime.t -> t
+val time : Time_ns.t -> t
 val series : Series.t -> t
 val sort : ?descending:bool -> t -> t
 val sort_by : ?descending:bool -> t -> by:t list -> t

--- a/lib/series.ml
+++ b/lib/series.ml
@@ -46,6 +46,16 @@ module T = struct
     datetime_option name (List.map dates ~f:(Option.map ~f:Common.Naive_datetime.of_date))
   ;;
 
+  let time string times =
+    datetime string (List.map times ~f:Common.Naive_datetime.of_time_ns_exn)
+  ;;
+
+  let time_option string times =
+    datetime_option
+      string
+      (List.map times ~f:(Option.map ~f:Common.Naive_datetime.of_time_ns_exn))
+  ;;
+
   external date : string -> Common.Naive_date.t list -> t = "rust_series_new_date"
 
   let date name dates = date name (List.map dates ~f:Common.Naive_date.of_date)

--- a/lib/series.mli
+++ b/lib/series.mli
@@ -18,6 +18,8 @@ val datetime : string -> Common.Naive_datetime.t list -> t
 val datetime_option : string -> Common.Naive_datetime.t option list -> t
 val datetime' : string -> Date.t list -> t
 val datetime_option' : string -> Date.t option list -> t
+val time : string -> Time_ns.t list -> t
+val time_option : string -> Time_ns.t option list -> t
 
 val date_range
   :  ?every:string

--- a/rust/polars-ocaml/src/misc.rs
+++ b/rust/polars-ocaml/src/misc.rs
@@ -64,7 +64,7 @@ fn rust_time_ns_to_naive_datetime(
 ) -> OCaml<Option<DynBox<NaiveDateTime>>> {
     let OCamlInt63(ns_since_epoch) = time_ns.to_rust(cr);
 
-    // We use euclid division here instead of the usual div (/) and mod (/)
+    // We use Euclidean division here instead of the usual div (/) and mod (%)
     // operations since we need the remainder to be non-negative.
     NaiveDateTime::from_timestamp_opt(
         ns_since_epoch.div_euclid(1_000_000_000),

--- a/rust/polars-ocaml/src/misc.rs
+++ b/rust/polars-ocaml/src/misc.rs
@@ -58,6 +58,33 @@ fn rust_naive_datetime_to_string(
 }
 
 #[ocaml_interop_export]
+fn rust_time_ns_to_naive_datetime(
+    cr: &mut &mut OCamlRuntime,
+    time_ns: OCamlRef<OCamlInt63>,
+) -> OCaml<Option<DynBox<NaiveDateTime>>> {
+    let OCamlInt63(ns_since_epoch) = time_ns.to_rust(cr);
+
+    // We use euclid division here instead of the usual div (/) and mod (/)
+    // operations since we need the remainder to be non-negative.
+    NaiveDateTime::from_timestamp_opt(
+        ns_since_epoch.div_euclid(1_000_000_000),
+        ns_since_epoch.rem_euclid(1_000_000_000) as u32,
+    )
+    .map(Abstract)
+    .to_ocaml(cr)
+}
+
+#[ocaml_interop_export]
+fn rust_naive_datetime_to_timestamp_nanos(
+    cr: &mut &mut OCamlRuntime,
+    datetime: OCamlRef<DynBox<NaiveDateTime>>,
+) -> OCaml<OCamlInt> {
+    let Abstract(datetime) = datetime.to_rust(cr);
+
+    datetime.timestamp_nanos().to_ocaml(cr)
+}
+
+#[ocaml_interop_export]
 fn rust_schema_create(
     cr: &mut &mut OCamlRuntime,
     fields: OCamlRef<OCamlList<(String, DataType)>>,

--- a/test/panic_test.ml
+++ b/test/panic_test.ml
@@ -18,6 +18,8 @@ let%expect_test "test" =
   |> String.split_lines
   |> List.filter ~f:(Fn.non (String.is_substring ~substring:" at "))
      (* Lines containing " at " correpond to file paths, which are noisy *)
+  |> Fn.flip List.take 7
+     (* Only take first few lines which are stable across dev and release builds *)
   |> String.concat_lines
   |> String.filter ~f:(Fn.non Char.is_digit)
      (* Remvoe all digits which may correspond to line/column numbers *)
@@ -30,36 +32,5 @@ let%expect_test "test" =
        : polars_ocaml::utils::rust_record_panic_backtraces::{{closure}}::{{closure}}
        : <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
        : std::panicking::rust_panic_with_hook
-       : std::panicking::begin_panic_handler::{{closure}}
-       : std::sys_common::backtrace::__rust_end_short_backtrace
-       : rust_begin_unwind
-       : core::panicking::panic_fmt
-       : polars_ocaml::misc::rust_test_panic::{{closure}}
-       : std::panicking::try::do_call
-       : __rust_try
-      : std::panicking::try
-      : std::panic::catch_unwind
-      : rust_test_panic
-      : camlPolars__Common__fun_
-      : camlExpect_test_helpers_base__fun_
-      : camlBase__Exn__protectx_
-      : camlExpect_test_helpers_base__require_does_raise_
-      : camlPolars_tests__Panic_test__fun_
-      : camlExpect_test_collector__exec_
-      : camlExpect_test_collector__fun_
-      : camlPpx_inline_test_lib__time_without_resetting_random_seeds_
-      : camlPpx_inline_test_lib__time_and_reset_random_seeds_
-      : camlPpx_inline_test_lib__test_inner_
-      : camlPolars_tests__Panic_test__entry
-      : caml_program
-      : caml_start_program
-      : caml_startup_common
-      : caml_startup_exn
-      : caml_startup
-      : caml_main
-      : main
-      : <unknown>
-      : __libc_start_main
-      : _start
-    ") |}]
+       : std::panicking::begin_panic_handler::{{closure}} |}]
 ;;

--- a/test/time_ns_test.ml
+++ b/test/time_ns_test.ml
@@ -1,0 +1,12 @@
+open! Core
+open! Polars
+
+let%expect_test "Time_ns.t roundtrips between Common.Naive_datetime.t" =
+  Base_quickcheck.Test.run_exn
+    (module Time_ns_unix)
+    ~f:(fun time_ns ->
+      let time_ns' =
+        Common.Naive_datetime.of_time_ns_exn time_ns |> Common.Naive_datetime.to_time_ns
+      in
+      [%test_result: Time_ns_unix.t] ~expect:time_ns time_ns')
+;;


### PR DESCRIPTION
Closes https://github.com/mt-caret/polars-ocaml/issues/60.

Also contains some work done to support building on 32bit since the memory layout of `Time_ns.t` depends on the platform architecture, but abandoned this attempt since polars doesn't seem to support 32bit architectures in some of its crates.