### PR TITLE
Add Uniform_array.t based series creation

### DIFF
--- a/lib/series.ml
+++ b/lib/series.ml
@@ -31,7 +31,10 @@ module T = struct
   (* TODO: the astute reader will realize that this is quite terrible when
      trying to passing float arrays! Unfortunately it's not clear to me how
      to pass regular arrays safely to Rust, whereas this is definitely safe
-     since [Uniform_array.t] guarantees elements are boxed. *)
+     since [Uniform_array.t] guarantees elements are boxed.
+
+     See https://github.com/mt-caret/polars-ocaml/pull/67 for how naively trying to
+     transmute on the Rust side doesn't work. *)
   external create'
     :  'a Data_type.Typed.t
     -> string

--- a/lib/series.ml
+++ b/lib/series.ml
@@ -14,6 +14,24 @@ module T = struct
     -> t
     = "rust_series_new_option"
 
+  (* TODO: the astute reader will realize that this is quite terrible when
+     trying to passing float arrays! Unfortunately it's not clear to me how
+     to pass regular arrays safely to Rust, whereas this is definitely safe
+     since [Uniform_array.t] guarantees elements are boxed. *)
+  external create'
+    :  'a Data_type.Typed.t
+    -> string
+    -> 'a Uniform_array.t
+    -> t
+    = "rust_series_new_array"
+
+  external createo'
+    :  'a Data_type.Typed.t
+    -> string
+    -> 'a option Uniform_array.t
+    -> t
+    = "rust_series_new_option_array"
+
   let int = create Int64
   let into = createo Int64
   let float = create Float64

--- a/lib/series.mli
+++ b/lib/series.mli
@@ -4,6 +4,8 @@ type t
 
 val create : 'a Data_type.Typed.t -> string -> 'a list -> t
 val createo : 'a Data_type.Typed.t -> string -> 'a option list -> t
+val create' : 'a Data_type.Typed.t -> string -> 'a Uniform_array.t -> t
+val createo' : 'a Data_type.Typed.t -> string -> 'a option Uniform_array.t -> t
 val int : string -> int list -> t
 val into : string -> int option list -> t
 val float : string -> float list -> t

--- a/rust/polars-ocaml/src/series.rs
+++ b/rust/polars-ocaml/src/series.rs
@@ -204,6 +204,38 @@ fn rust_series_new_option(
     OCaml::box_value(cr, series)
 }
 
+#[ocaml_interop_export(raise_on_err)]
+fn rust_series_new_array(
+    cr: &mut &mut OCamlRuntime,
+    data_type: OCamlRef<GADTDataType>,
+    name: OCamlRef<String>,
+    values: OCamlRef<OCamlUniformArray<DummyBoxRoot>>,
+) -> OCaml<DynBox<Series>> {
+    let name: String = name.to_rust(cr);
+    let data_type: GADTDataType = data_type.to_rust(cr);
+    let values: Vec<DummyBoxRoot> = values.to_rust(cr);
+
+    let series = series_new(cr, &data_type, name, values, false)?;
+
+    OCaml::box_value(cr, series)
+}
+
+#[ocaml_interop_export(raise_on_err)]
+fn rust_series_new_option_array(
+    cr: &mut &mut OCamlRuntime,
+    data_type: OCamlRef<GADTDataType>,
+    name: OCamlRef<String>,
+    values: OCamlRef<OCamlUniformArray<DummyBoxRoot>>,
+) -> OCaml<DynBox<Series>> {
+    let name: String = name.to_rust(cr);
+    let data_type: GADTDataType = data_type.to_rust(cr);
+    let values: Vec<DummyBoxRoot> = values.to_rust(cr);
+
+    let series = series_new(cr, &data_type, name, values, true)?;
+
+    OCaml::box_value(cr, series)
+}
+
 #[ocaml_interop_export]
 fn rust_series_new_datetime(
     cr: &mut &mut OCamlRuntime,


### PR DESCRIPTION
This... is not great. I can't really figure out how to allow unboxed float arrays to be properly parsed on the Rust side since that would either require overlapping impls or some sort of type reflection (a la [Haskell's Typeable](https://stackoverflow.com/questions/75932438/haskell-support-for-type-reflection)).

We're instead taking `Unform_array.t`, which is essentially `array` but with the promise that there is no unboxing happening. Obviously this is a terrible way to pass float arrays, and I'm quite unhappy about this compromise.