### PR TITLE
Convert several macros to functions

### DIFF
--- a/rust/polars-ocaml/src/data_frame.rs
+++ b/rust/polars-ocaml/src/data_frame.rs
@@ -248,7 +248,7 @@ fn rust_data_frame_column(
 ) -> OCaml<Result<DynBox<PolarsSeries>, String>> {
     let name: String = name.to_rust(cr);
 
-    dyn_box_result!(cr, |data_frame| {
+    dyn_box_result(cr, data_frame, |data_frame| {
         let data_frame = data_frame.borrow();
         data_frame
             .column(&name)
@@ -356,7 +356,7 @@ fn rust_data_frame_vstack(
     data_frame: OCamlRef<DynBox<PolarsDataFrame>>,
     other: OCamlRef<DynBox<PolarsDataFrame>>,
 ) -> OCaml<Result<DynBox<()>, String>> {
-    dyn_box_result!(cr, |data_frame, other| {
+    dyn_box_result2(cr, data_frame, other, |data_frame, other| {
         let other = match Rc::try_unwrap(other) {
             Ok(data_frame) => data_frame.into_inner(),
             Err(data_frame) => data_frame.borrow().clone(),
@@ -403,7 +403,7 @@ fn rust_data_frame_pivot(
 
     let stable: bool = stable.to_rust(cr);
 
-    dyn_box_result!(cr, |data_frame| {
+    dyn_box_result(cr, data_frame, |data_frame| {
         let result = if stable {
             pivot::pivot_stable(
                 &data_frame.borrow(),
@@ -465,7 +465,7 @@ fn rust_data_frame_melt(
         streamable,
     };
 
-    dyn_box_result!(cr, |data_frame| {
+    dyn_box_result(cr, data_frame, |data_frame| {
         let data_frame = data_frame.borrow();
         data_frame
             .melt2(melt_args)
@@ -485,7 +485,7 @@ fn rust_data_frame_sort(
     let descending: Vec<bool> = descending.to_rust(cr);
     let maintain_order: bool = maintain_order.to_rust(cr);
 
-    dyn_box_result!(cr, |data_frame| {
+    dyn_box_result(cr, data_frame, |data_frame| {
         let data_frame = data_frame.borrow();
         data_frame
             .sort(by_column, descending, maintain_order)
@@ -541,7 +541,7 @@ fn rust_data_frame_sample_n(
         .to_rust::<Coerce<_, Option<i64>, Option<u64>>>(cr)
         .get()?;
 
-    dyn_box_result!(cr, |data_frame| {
+    dyn_box_result(cr, data_frame, |data_frame| {
         let data_frame = data_frame.borrow();
         data_frame
             .sample_n(n, with_replacement, shuffle, seed)
@@ -575,7 +575,7 @@ fn rust_data_frame_fill_null_with_strategy(
 ) -> OCaml<Result<DynBox<PolarsDataFrame>, String>> {
     let PolarsFillNullStrategy(strategy) = strategy.to_rust(cr);
 
-    dyn_box_result!(cr, |data_frame| {
+    dyn_box_result(cr, data_frame, |data_frame| {
         let data_frame = data_frame.borrow();
         data_frame
             .fill_null(strategy)
@@ -591,7 +591,7 @@ fn rust_data_frame_interpolate(
 ) -> OCaml<Result<DynBox<PolarsDataFrame>, String>> {
     let PolarsInterpolationMethod(method) = method.to_rust(cr);
 
-    dyn_box_result!(cr, |data_frame| {
+    dyn_box_result(cr, data_frame, |data_frame| {
         let data_frame = data_frame.borrow();
 
         let series = data_frame
@@ -620,7 +620,7 @@ fn rust_data_frame_upsample(
     let offset: String = offset.to_rust(cr);
     let stable: bool = stable.to_rust(cr);
 
-    dyn_box_result!(cr, |data_frame| {
+    dyn_box_result(cr, data_frame, |data_frame| {
         let result = if stable {
             data_frame.borrow().upsample_stable(
                 &by,
@@ -649,7 +649,7 @@ fn rust_data_frame_explode(
 ) -> OCaml<Result<DynBox<PolarsDataFrame>, String>> {
     let columns: Vec<String> = columns.to_rust(cr);
 
-    dyn_box_result!(cr, |data_frame| {
+    dyn_box_result(cr, data_frame, |data_frame| {
         let data_frame = data_frame.borrow();
         data_frame
             .explode(columns)

--- a/rust/polars-ocaml/src/data_frame.rs
+++ b/rust/polars-ocaml/src/data_frame.rs
@@ -190,7 +190,7 @@ fn rust_data_frame_clear(
     cr: &mut &mut OCamlRuntime,
     data_frame: OCamlRef<DynBox<PolarsDataFrame>>,
 ) -> OCaml<DynBox<PolarsDataFrame>> {
-    dyn_box!(cr, |data_frame| {
+    dyn_box(cr, data_frame, |data_frame| {
         let data_frame = data_frame.borrow();
         Rc::new(RefCell::new(data_frame.clear()))
     })
@@ -232,7 +232,7 @@ fn rust_data_frame_lazy(
     cr: &mut &mut OCamlRuntime,
     data_frame: OCamlRef<DynBox<PolarsDataFrame>>,
 ) -> OCaml<DynBox<LazyFrame>> {
-    dyn_box!(cr, |data_frame| {
+    dyn_box(cr, data_frame, |data_frame| {
         match Rc::try_unwrap(data_frame) {
             Ok(data_frame) => data_frame.into_inner().lazy(),
             Err(data_frame) => data_frame.borrow().clone().lazy(),
@@ -503,7 +503,7 @@ fn rust_data_frame_head(
         .to_rust::<Coerce<_, Option<i64>, Option<usize>>>(cr)
         .get()?;
 
-    dyn_box!(cr, |data_frame| {
+    dyn_box(cr, data_frame, |data_frame| {
         let data_frame = data_frame.borrow();
         Rc::new(RefCell::new(data_frame.head(length)))
     })
@@ -519,7 +519,7 @@ fn rust_data_frame_tail(
         .to_rust::<Coerce<_, Option<i64>, Option<usize>>>(cr)
         .get()?;
 
-    dyn_box!(cr, |data_frame| {
+    dyn_box(cr, data_frame, |data_frame| {
         let data_frame = data_frame.borrow();
         Rc::new(RefCell::new(data_frame.tail(length)))
     })
@@ -662,7 +662,7 @@ fn rust_data_frame_schema(
     cr: &mut &mut OCamlRuntime,
     data_frame: OCamlRef<DynBox<PolarsDataFrame>>,
 ) -> OCaml<DynBox<Schema>> {
-    dyn_box!(cr, |data_frame| {
+    dyn_box(cr, data_frame, |data_frame| {
         let data_frame = data_frame.borrow();
         data_frame.schema()
     })

--- a/rust/polars-ocaml/src/expr.rs
+++ b/rust/polars-ocaml/src/expr.rs
@@ -58,7 +58,7 @@ fn rust_expr_exclude(
     names: OCamlRef<OCamlList<String>>,
 ) -> OCaml<DynBox<Expr>> {
     let names: Vec<String> = names.to_rust(cr);
-    dyn_box!(cr, |expr| expr.exclude(names))
+    dyn_box(cr, expr, |expr| expr.exclude(names))
 }
 
 #[ocaml_interop_export]
@@ -122,7 +122,7 @@ fn rust_expr_naive_date(
     cr: &mut &mut OCamlRuntime,
     value: OCamlRef<DynBox<NaiveDate>>,
 ) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |value| lit(value))
+    dyn_box(cr, value, |value| lit(value))
 }
 
 #[ocaml_interop_export]
@@ -130,7 +130,7 @@ fn rust_expr_naive_datetime(
     cr: &mut &mut OCamlRuntime,
     value: OCamlRef<DynBox<NaiveDateTime>>,
 ) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |value| lit(value))
+    dyn_box(cr, value, |value| lit(value))
 }
 
 #[ocaml_interop_export]
@@ -138,7 +138,7 @@ fn rust_expr_series(
     cr: &mut &mut OCamlRuntime,
     series: OCamlRef<DynBox<crate::series::PolarsSeries>>,
 ) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |series| {
+    dyn_box(cr, series, |series| {
         match Rc::try_unwrap(series) {
             Ok(series) => lit(series.into_inner()),
             Err(series) => lit(series.borrow().clone()),
@@ -155,7 +155,7 @@ fn rust_expr_cast(
 ) -> OCaml<DynBox<Expr>> {
     let PolarsDataType(data_type): PolarsDataType = data_type.to_rust(cr);
     let is_strict: bool = is_strict.to_rust(cr);
-    dyn_box!(cr, |expr| {
+    dyn_box(cr, expr, |expr| {
         if is_strict {
             expr.strict_cast(data_type)
         } else {
@@ -171,7 +171,7 @@ fn rust_expr_sort(
     descending: OCamlRef<bool>,
 ) -> OCaml<DynBox<Expr>> {
     let descending: bool = descending.to_rust(cr);
-    dyn_box!(cr, |expr| expr.sort(descending))
+    dyn_box(cr, expr, |expr| expr.sort(descending))
 }
 
 #[ocaml_interop_export]
@@ -184,7 +184,7 @@ fn rust_expr_sort_by(
     let by = unwrap_abstract_vec(by.to_rust(cr));
     let descending: bool = descending.to_rust(cr);
     let descending = vec![descending; by.len()];
-    dyn_box!(cr, |expr| expr.sort_by(by, descending))
+    dyn_box(cr, expr, |expr| expr.sort_by(by, descending))
 }
 
 #[ocaml_interop_export]
@@ -194,7 +194,7 @@ fn rust_expr_set_sorted_flag(
     is_sorted: OCamlRef<IsSorted>,
 ) -> OCaml<DynBox<Expr>> {
     let PolarsIsSorted(is_sorted) = is_sorted.to_rust(cr);
-    dyn_box!(cr, |expr| expr.set_sorted_flag(is_sorted))
+    dyn_box(cr, expr, |expr| expr.set_sorted_flag(is_sorted))
 }
 
 expr_op!(rust_expr_first, |expr| expr.first());
@@ -218,7 +218,7 @@ fn rust_expr_head(
         .to_rust::<Coerce<_, Option<i64>, Option<usize>>>(cr)
         .get()?;
 
-    dyn_box!(cr, |expr| expr.head(length))
+    dyn_box(cr, expr, |expr| expr.head(length))
 }
 
 #[ocaml_interop_export(raise_on_err)]
@@ -231,7 +231,7 @@ fn rust_expr_tail(
         .to_rust::<Coerce<_, Option<i64>, Option<usize>>>(cr)
         .get()?;
 
-    dyn_box!(cr, |expr| expr.tail(length))
+    dyn_box(cr, expr, |expr| expr.tail(length))
 }
 
 expr_op!(rust_expr_take, |expr, idx| expr.take(idx));
@@ -254,7 +254,7 @@ fn rust_expr_sample_n(
         .get()?;
     let fixed_seed = fixed_seed.to_rust(cr);
 
-    dyn_box!(cr, |expr| expr.sample_n(
+    dyn_box(cr, expr, |expr| expr.sample_n(
         n,
         with_replacement,
         shuffle,
@@ -274,7 +274,7 @@ fn rust_expr_clip_min_float(
     min: OCamlRef<OCamlFloat>,
 ) -> OCaml<DynBox<Expr>> {
     let min: f64 = min.to_rust(cr);
-    dyn_box!(cr, |expr| expr.clip_min(AnyValue::Float64(min)))
+    dyn_box(cr, expr, |expr| expr.clip_min(AnyValue::Float64(min)))
 }
 
 #[ocaml_interop_export]
@@ -284,7 +284,7 @@ fn rust_expr_clip_max_float(
     max: OCamlRef<OCamlFloat>,
 ) -> OCaml<DynBox<Expr>> {
     let max: f64 = max.to_rust(cr);
-    dyn_box!(cr, |expr| expr.clip_max(AnyValue::Float64(max)))
+    dyn_box(cr, expr, |expr| expr.clip_max(AnyValue::Float64(max)))
 }
 
 #[ocaml_interop_export]
@@ -294,7 +294,7 @@ fn rust_expr_clip_min_int(
     min: OCamlRef<OCamlInt>,
 ) -> OCaml<DynBox<Expr>> {
     let min: i64 = min.to_rust(cr);
-    dyn_box!(cr, |expr| expr.clip_min(AnyValue::Int64(min)))
+    dyn_box(cr, expr, |expr| expr.clip_min(AnyValue::Int64(min)))
 }
 
 #[ocaml_interop_export]
@@ -304,7 +304,7 @@ fn rust_expr_clip_max_int(
     max: OCamlRef<OCamlInt>,
 ) -> OCaml<DynBox<Expr>> {
     let max: i64 = max.to_rust(cr);
-    dyn_box!(cr, |expr| expr.clip_max(AnyValue::Int64(max)))
+    dyn_box(cr, expr, |expr| expr.clip_max(AnyValue::Int64(max)))
 }
 
 expr_op!(rust_expr_pow, |base, exponent| base.pow(exponent));
@@ -337,7 +337,7 @@ fn rust_expr_over(
 ) -> OCaml<DynBox<Expr>> {
     let PolarsWindowMapping(mapping_strategy) = mapping_strategy.to_rust(cr);
     let partition_by: Vec<_> = unwrap_abstract_vec(partition_by.to_rust(cr));
-    dyn_box!(cr, |expr| {
+    dyn_box(cr, expr, |expr| {
         expr.over_with_options(
             &partition_by,
             WindowOptions {
@@ -391,7 +391,7 @@ fn rust_expr_interpolate(
     method: OCamlRef<InterpolationMethod>,
 ) -> OCaml<DynBox<Expr>> {
     let PolarsInterpolationMethod(method) = method.to_rust(cr);
-    dyn_box!(cr, |expr| expr.interpolate(method))
+    dyn_box(cr, expr, |expr| expr.interpolate(method))
 }
 
 #[ocaml_interop_export(raise_on_err)]
@@ -402,12 +402,12 @@ fn rust_expr_rank(
     descending: OCamlRef<bool>,
     seed: OCamlRef<Option<OCamlInt>>,
 ) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| {
+    dyn_box_with_cr(cr, expr, |cr, expr| {
         let PolarsRankMethod(method) = method.to_rust(cr);
         let descending: bool = descending.to_rust(cr);
         let seed = seed
             .to_rust::<Coerce<_, Option<i64>, Option<u64>>>(cr)
-            .get()?;
+            .get().unwrap();
         expr.rank(RankOptions { method, descending }, seed)
     })
 }
@@ -441,7 +441,7 @@ fn rust_expr_when_then(
         .into_iter()
         .map(|(Abstract(when), Abstract(then))| (when, then))
         .collect();
-    dyn_box!(cr, |otherwise| {
+    dyn_box(cr, otherwise, |otherwise| {
         let mut ret = WhenThenClause::Empty;
 
         for (when_expr, then_expr) in when_then_clauses {
@@ -473,7 +473,7 @@ fn rust_expr_shift(
     periods: OCamlRef<OCamlInt>,
     fill_value: OCamlRef<Option<DynBox<Expr>>>,
 ) -> OCaml<DynBox<Expr>> {
-    dyn_box!(cr, |expr| {
+    dyn_box_with_cr(cr, expr, |cr, expr| {
         let periods: i64 = periods.to_rust(cr);
         let fill_value: Option<Abstract<Expr>> = fill_value.to_rust(cr);
 
@@ -491,7 +491,7 @@ fn rust_expr_cum_count(
     reverse: OCamlRef<bool>,
 ) -> OCaml<DynBox<Expr>> {
     let reverse: bool = reverse.to_rust(cr);
-    dyn_box!(cr, |expr| expr.cumcount(reverse))
+    dyn_box(cr, expr, |expr| expr.cumcount(reverse))
 }
 
 #[ocaml_interop_export]
@@ -501,7 +501,7 @@ fn rust_expr_cum_sum(
     reverse: OCamlRef<bool>,
 ) -> OCaml<DynBox<Expr>> {
     let reverse: bool = reverse.to_rust(cr);
-    dyn_box!(cr, |expr| expr.cumsum(reverse))
+    dyn_box(cr, expr, |expr| expr.cumsum(reverse))
 }
 
 #[ocaml_interop_export]
@@ -511,7 +511,7 @@ fn rust_expr_cum_prod(
     reverse: OCamlRef<bool>,
 ) -> OCaml<DynBox<Expr>> {
     let reverse: bool = reverse.to_rust(cr);
-    dyn_box!(cr, |expr| expr.cumprod(reverse))
+    dyn_box(cr, expr, |expr| expr.cumprod(reverse))
 }
 
 #[ocaml_interop_export]
@@ -521,7 +521,7 @@ fn rust_expr_cum_min(
     reverse: OCamlRef<bool>,
 ) -> OCaml<DynBox<Expr>> {
     let reverse: bool = reverse.to_rust(cr);
-    dyn_box!(cr, |expr| expr.cummin(reverse))
+    dyn_box(cr, expr, |expr| expr.cummin(reverse))
 }
 
 #[ocaml_interop_export]
@@ -531,7 +531,7 @@ fn rust_expr_cum_max(
     reverse: OCamlRef<bool>,
 ) -> OCaml<DynBox<Expr>> {
     let reverse: bool = reverse.to_rust(cr);
-    dyn_box!(cr, |expr| expr.cummax(reverse))
+    dyn_box(cr, expr, |expr| expr.cummax(reverse))
 }
 
 #[ocaml_interop_export]
@@ -541,7 +541,7 @@ fn rust_expr_alias(
     name: OCamlRef<String>,
 ) -> OCaml<DynBox<Expr>> {
     let name: String = name.to_rust(cr);
-    dyn_box!(cr, |expr| expr.alias(&name))
+    dyn_box(cr, expr, |expr| expr.alias(&name))
 }
 
 #[ocaml_interop_export]
@@ -551,7 +551,7 @@ fn rust_expr_prefix(
     prefix: OCamlRef<String>,
 ) -> OCaml<DynBox<Expr>> {
     let prefix: String = prefix.to_rust(cr);
-    dyn_box!(cr, |expr| expr.prefix(&prefix))
+    dyn_box(cr, expr, |expr| expr.prefix(&prefix))
 }
 
 #[ocaml_interop_export]
@@ -561,7 +561,7 @@ fn rust_expr_suffix(
     suffix: OCamlRef<String>,
 ) -> OCaml<DynBox<Expr>> {
     let suffix: String = suffix.to_rust(cr);
-    dyn_box!(cr, |expr| expr.suffix(&suffix))
+    dyn_box(cr, expr, |expr| expr.suffix(&suffix))
 }
 
 #[ocaml_interop_export(raise_on_err)]
@@ -572,7 +572,7 @@ fn rust_expr_round(
 ) -> OCaml<DynBox<Expr>> {
     let decimals = decimals.to_rust::<Coerce<_, i64, u32>>(cr).get()?;
 
-    dyn_box!(cr, |expr| expr.round(decimals))
+    dyn_box(cr, expr, |expr| expr.round(decimals))
 }
 
 expr_op!(rust_expr_eq, |expr, other| expr.eq(other));
@@ -598,7 +598,7 @@ fn rust_expr_dt_strftime(
     format: OCamlRef<String>,
 ) -> OCaml<DynBox<Expr>> {
     let format: String = format.to_rust(cr);
-    dyn_box!(cr, |expr| expr.dt().to_string(&format))
+    dyn_box(cr, expr, |expr| expr.dt().to_string(&format))
 }
 
 #[ocaml_interop_export]
@@ -608,7 +608,7 @@ fn rust_expr_dt_convert_time_zone(
     timezone: OCamlRef<String>,
 ) -> OCaml<DynBox<Expr>> {
     let timezone: String = timezone.to_rust(cr);
-    dyn_box!(cr, |expr| expr.dt().convert_time_zone(timezone))
+    dyn_box(cr, expr, |expr| expr.dt().convert_time_zone(timezone))
 }
 
 #[ocaml_interop_export]
@@ -620,7 +620,7 @@ fn rust_expr_dt_replace_time_zone(
 ) -> OCaml<DynBox<Expr>> {
     let timezone: Option<String> = timezone.to_rust(cr);
     let use_earliest: Option<bool> = use_earliest.to_rust(cr);
-    dyn_box!(cr, |expr| {
+    dyn_box(cr, expr, |expr| {
         expr.dt().replace_time_zone(timezone, use_earliest)
     })
 }
@@ -729,7 +729,7 @@ fn rust_expr_str_split(
 ) -> OCaml<DynBox<Expr>> {
     let by: String = by.to_rust(cr);
     let inclusive = inclusive.to_rust(cr);
-    dyn_box!(cr, |expr| {
+    dyn_box(cr, expr, |expr| {
         if inclusive {
             expr.str().split_inclusive(&by)
         } else {
@@ -748,7 +748,7 @@ fn rust_expr_str_strptime(
     let PolarsDataType(data_type): PolarsDataType = data_type.to_rust(cr);
     let format: String = format.to_rust(cr);
 
-    dyn_box!(cr, |expr| {
+    dyn_box(cr, expr, |expr| {
         // TODO: make other options configurable
         let options = StrptimeOptions {
             format: Some(format),
@@ -852,7 +852,7 @@ fn rust_expr_str_extract(
     let pat: String = pat.to_rust(cr);
     let group_index = group_index.to_rust::<Coerce<_, i64, usize>>(cr).get()?;
 
-    dyn_box!(cr, |expr| {
+    dyn_box(cr, expr, |expr| {
         let f = move |series: Series| {
             Ok(Some(
                 series.utf8()?.extract(&pat, group_index)?.into_series(),
@@ -938,7 +938,7 @@ fn rust_expr_str_strip(
     matches: OCamlRef<Option<String>>,
 ) -> OCaml<DynBox<Expr>> {
     let matches: Option<String> = matches.to_rust(cr);
-    dyn_box!(cr, |expr| expr.str().strip(matches))
+    dyn_box(cr, expr, |expr| expr.str().strip(matches))
 }
 
 #[ocaml_interop_export]
@@ -948,7 +948,7 @@ fn rust_expr_str_lstrip(
     matches: OCamlRef<Option<String>>,
 ) -> OCaml<DynBox<Expr>> {
     let matches: Option<String> = matches.to_rust(cr);
-    dyn_box!(cr, |expr| expr.str().lstrip(matches))
+    dyn_box(cr, expr, |expr| expr.str().lstrip(matches))
 }
 
 #[ocaml_interop_export]
@@ -958,7 +958,7 @@ fn rust_expr_str_rstrip(
     matches: OCamlRef<Option<String>>,
 ) -> OCaml<DynBox<Expr>> {
     let matches: Option<String> = matches.to_rust(cr);
-    dyn_box!(cr, |expr| expr.str().rstrip(matches))
+    dyn_box(cr, expr, |expr| expr.str().rstrip(matches))
 }
 
 expr_op!(rust_expr_str_to_lowercase, |expr| expr.str().to_lowercase());
@@ -975,7 +975,7 @@ fn rust_expr_str_slice(
     let length = length
         .to_rust::<Coerce<_, Option<i64>, Option<u64>>>(cr)
         .get()?;
-    dyn_box!(cr, |expr| expr.str().str_slice(start, length))
+    dyn_box(cr, expr, |expr| expr.str().str_slice(start, length))
 }
 
 expr_op!(rust_expr_list_lengths, |expr| expr.list().lengths());
@@ -994,5 +994,5 @@ fn rust_expr_list_eval(
     parallel: OCamlRef<bool>,
 ) -> OCaml<DynBox<Expr>> {
     let parallel = parallel.to_rust(cr);
-    dyn_box!(cr, |expr, other| expr.list().eval(other, parallel))
+    dyn_box2(cr, expr, other, |expr, other| expr.list().eval(other, parallel))
 }

--- a/rust/polars-ocaml/src/lazy_frame.rs
+++ b/rust/polars-ocaml/src/lazy_frame.rs
@@ -78,7 +78,7 @@ fn rust_lazy_frame_cache(
     cr: &mut &mut OCamlRuntime,
     lazy_frame: OCamlRef<DynBox<LazyFrame>>,
 ) -> OCaml<DynBox<LazyFrame>> {
-    dyn_box!(cr, |lazy_frame| lazy_frame.cache())
+    dyn_box(cr, lazy_frame, |lazy_frame| lazy_frame.cache())
 }
 
 #[ocaml_interop_export]
@@ -182,7 +182,7 @@ fn rust_lazy_frame_filter(
     lazy_frame: OCamlRef<DynBox<LazyFrame>>,
     expr: OCamlRef<DynBox<Expr>>,
 ) -> OCaml<DynBox<LazyFrame>> {
-    dyn_box!(cr, |lazy_frame, expr| lazy_frame.filter(expr))
+    dyn_box2(cr, lazy_frame, expr, |lazy_frame, expr| lazy_frame.filter(expr))
 }
 
 #[ocaml_interop_export]
@@ -193,7 +193,7 @@ fn rust_lazy_frame_select(
 ) -> OCaml<DynBox<LazyFrame>> {
     let exprs = unwrap_abstract_vec(exprs.to_rust(cr));
 
-    dyn_box!(cr, |lazy_frame| lazy_frame.select(&exprs))
+    dyn_box(cr, lazy_frame, |lazy_frame| lazy_frame.select(&exprs))
 }
 
 #[ocaml_interop_export]
@@ -204,7 +204,7 @@ fn rust_lazy_frame_with_columns(
 ) -> OCaml<DynBox<LazyFrame>> {
     let exprs = unwrap_abstract_vec(exprs.to_rust(cr));
 
-    dyn_box!(cr, |lazy_frame| lazy_frame.with_columns(&exprs))
+    dyn_box(cr, lazy_frame, |lazy_frame| lazy_frame.with_columns(&exprs))
 }
 
 #[ocaml_interop_export]
@@ -219,7 +219,7 @@ fn rust_lazy_frame_groupby(
     let by = unwrap_abstract_vec(by.to_rust(cr));
     let agg = unwrap_abstract_vec(agg.to_rust(cr));
 
-    dyn_box!(cr, |lazy_frame| {
+    dyn_box(cr, lazy_frame, |lazy_frame| {
         let groupby = if is_stable {
             lazy_frame.groupby_stable(by)
         } else {
@@ -285,7 +285,7 @@ fn rust_lazy_frame_groupby_dynamic(
 
     let agg = unwrap_abstract_vec(agg.to_rust(cr));
 
-    dyn_box!(cr, |lazy_frame, index_column| {
+    dyn_box2(cr, lazy_frame, index_column, |lazy_frame, index_column| {
         lazy_frame
             .groupby_dynamic(index_column, by, options)
             .agg(agg)
@@ -305,7 +305,7 @@ fn rust_lazy_frame_join(
     let right_on = unwrap_abstract_vec(right_on.to_rust(cr));
     let PolarsJoinType(how) = how.to_rust(cr);
 
-    dyn_box!(cr, |lazy_frame, other| {
+    dyn_box2(cr, lazy_frame, other, |lazy_frame, other| {
         lazy_frame.join(other, &left_on, &right_on, JoinArgs::new(how))
     })
 }
@@ -333,7 +333,7 @@ fn rust_lazy_frame_sort(
         maintain_order: maintain_order.unwrap_or(sort_options.maintain_order),
     };
 
-    dyn_box!(cr, |lazy_frame| lazy_frame.sort(&by_column, sort_options))
+    dyn_box(cr, lazy_frame, |lazy_frame| lazy_frame.sort(&by_column, sort_options))
 }
 
 #[ocaml_interop_export]
@@ -412,7 +412,7 @@ fn rust_lazy_frame_melt(
         streamable,
     };
 
-    dyn_box!(cr, |lazy_frame| lazy_frame.melt(melt_args))
+    dyn_box(cr, lazy_frame, |lazy_frame| lazy_frame.melt(melt_args))
 }
 
 #[ocaml_interop_export(raise_on_err)]
@@ -423,7 +423,7 @@ fn rust_lazy_frame_limit(
 ) -> OCaml<DynBox<LazyFrame>> {
     let n = n.to_rust::<Coerce<_, i64, u32>>(cr).get()?;
 
-    dyn_box!(cr, |lazy_frame| lazy_frame.limit(n))
+    dyn_box(cr, lazy_frame, |lazy_frame| lazy_frame.limit(n))
 }
 
 #[ocaml_interop_export]
@@ -434,7 +434,7 @@ fn rust_lazy_frame_explode(
 ) -> OCaml<DynBox<LazyFrame>> {
     let columns = unwrap_abstract_vec(columns.to_rust(cr));
 
-    dyn_box!(cr, |lazy_frame| lazy_frame.explode(&columns))
+    dyn_box(cr, lazy_frame, |lazy_frame| lazy_frame.explode(&columns))
 }
 
 #[ocaml_interop_export]
@@ -445,7 +445,7 @@ fn rust_lazy_frame_with_streaming(
 ) -> OCaml<DynBox<LazyFrame>> {
     let toggle = toggle.to_rust(cr);
 
-    dyn_box!(cr, |lazy_frame| lazy_frame.with_streaming(toggle))
+    dyn_box(cr, lazy_frame, |lazy_frame| lazy_frame.with_streaming(toggle))
 }
 
 #[ocaml_interop_export]

--- a/rust/polars-ocaml/src/lazy_frame.rs
+++ b/rust/polars-ocaml/src/lazy_frame.rs
@@ -182,7 +182,9 @@ fn rust_lazy_frame_filter(
     lazy_frame: OCamlRef<DynBox<LazyFrame>>,
     expr: OCamlRef<DynBox<Expr>>,
 ) -> OCaml<DynBox<LazyFrame>> {
-    dyn_box2(cr, lazy_frame, expr, |lazy_frame, expr| lazy_frame.filter(expr))
+    dyn_box2(cr, lazy_frame, expr, |lazy_frame, expr| {
+        lazy_frame.filter(expr)
+    })
 }
 
 #[ocaml_interop_export]
@@ -333,7 +335,9 @@ fn rust_lazy_frame_sort(
         maintain_order: maintain_order.unwrap_or(sort_options.maintain_order),
     };
 
-    dyn_box(cr, lazy_frame, |lazy_frame| lazy_frame.sort(&by_column, sort_options))
+    dyn_box(cr, lazy_frame, |lazy_frame| {
+        lazy_frame.sort(&by_column, sort_options)
+    })
 }
 
 #[ocaml_interop_export]
@@ -445,7 +449,9 @@ fn rust_lazy_frame_with_streaming(
 ) -> OCaml<DynBox<LazyFrame>> {
     let toggle = toggle.to_rust(cr);
 
-    dyn_box(cr, lazy_frame, |lazy_frame| lazy_frame.with_streaming(toggle))
+    dyn_box(cr, lazy_frame, |lazy_frame| {
+        lazy_frame.with_streaming(toggle)
+    })
 }
 
 #[ocaml_interop_export]

--- a/rust/polars-ocaml/src/lazy_frame.rs
+++ b/rust/polars-ocaml/src/lazy_frame.rs
@@ -104,7 +104,7 @@ fn rust_lazy_frame_collect(
 ) -> OCaml<Result<DynBox<crate::data_frame::PolarsDataFrame>, String>> {
     let streaming = streaming.to_rust(cr);
 
-    dyn_box_result!(cr, |lazy_frame| {
+    dyn_box_result_with_cr(cr, lazy_frame, |cr, lazy_frame| {
         cr.releasing_runtime(|| {
             lazy_frame
                 .with_streaming(streaming)
@@ -171,7 +171,7 @@ fn rust_lazy_frame_fetch(
 ) -> OCaml<Result<DynBox<crate::data_frame::PolarsDataFrame>, String>> {
     let n_rows = n_rows.to_rust::<Coerce<_, i64, usize>>(cr).get()?;
 
-    dyn_box_result!(cr, |lazy_frame| {
+    dyn_box_result_with_cr(cr, lazy_frame, |cr, lazy_frame| {
         cr.releasing_runtime(|| lazy_frame.fetch(n_rows).map(|df| Rc::new(RefCell::new(df))))
     })
 }
@@ -459,7 +459,7 @@ fn rust_lazy_frame_schema(
     cr: &mut &mut OCamlRuntime,
     lazy_frame: OCamlRef<DynBox<LazyFrame>>,
 ) -> OCaml<Result<DynBox<Schema>, String>> {
-    dyn_box_result!(cr, |lazy_frame| {
+    dyn_box_result(cr, lazy_frame, |lazy_frame| {
         lazy_frame.schema().map(|schema| (*schema).clone())
     })
 }

--- a/rust/polars-ocaml/src/series.rs
+++ b/rust/polars-ocaml/src/series.rs
@@ -712,7 +712,7 @@ fn rust_series_sample_n(
         .to_rust::<Coerce<_, Option<i64>, Option<u64>>>(cr)
         .get()?;
 
-    dyn_box_result!(cr, |series| {
+    dyn_box_result(cr, series, |series| {
         let series = series.borrow();
         series
             .sample_n(n, with_replacement, shuffle, seed)
@@ -728,7 +728,7 @@ fn rust_series_fill_null_with_strategy(
 ) -> OCaml<Result<DynBox<PolarsSeries>, String>> {
     let PolarsFillNullStrategy(strategy) = strategy.to_rust(cr);
 
-    dyn_box_result!(cr, |series| {
+    dyn_box_result(cr, series, |series| {
         let series = series.borrow();
         series.fill_null(strategy).map(|s| Rc::new(RefCell::new(s)))
     })

--- a/rust/polars-ocaml/src/series.rs
+++ b/rust/polars-ocaml/src/series.rs
@@ -641,7 +641,7 @@ fn rust_series_to_data_frame(
     cr: &mut &mut OCamlRuntime,
     series: OCamlRef<DynBox<PolarsSeries>>,
 ) -> OCaml<DynBox<crate::data_frame::PolarsDataFrame>> {
-    dyn_box!(cr, |series| {
+    dyn_box(cr, series, |series| {
         let data_frame = match Rc::try_unwrap(series) {
             Ok(series) => series.into_inner().into_frame(),
             Err(series) => series.borrow().clone().into_frame(),
@@ -658,7 +658,7 @@ fn rust_series_sort(
 ) -> OCaml<DynBox<PolarsSeries>> {
     let descending: bool = descending.to_rust(cr);
 
-    dyn_box!(cr, |series| {
+    dyn_box(cr, series, |series| {
         let series = series.borrow();
         Rc::new(RefCell::new(series.sort(descending)))
     })
@@ -674,7 +674,7 @@ fn rust_series_head(
         .to_rust::<Coerce<_, Option<i64>, Option<usize>>>(cr)
         .get()?;
 
-    dyn_box!(cr, |series| {
+    dyn_box(cr, series, |series| {
         let series = series.borrow();
         Rc::new(RefCell::new(series.head(length)))
     })
@@ -690,7 +690,7 @@ fn rust_series_tail(
         .to_rust::<Coerce<_, Option<i64>, Option<usize>>>(cr)
         .get()?;
 
-    dyn_box!(cr, |series| {
+    dyn_box(cr, series, |series| {
         let series = series.borrow();
         Rc::new(RefCell::new(series.tail(length)))
     })
@@ -742,7 +742,7 @@ fn rust_series_interpolate(
 ) -> OCaml<DynBox<PolarsSeries>> {
     let PolarsInterpolationMethod(method) = method.to_rust(cr);
 
-    dyn_box!(cr, |series| {
+    dyn_box(cr, series, |series| {
         let series = series.borrow();
         Rc::new(RefCell::new(interpolate(&series, method)))
     })

--- a/rust/polars-ocaml/src/series.rs
+++ b/rust/polars-ocaml/src/series.rs
@@ -1,8 +1,8 @@
 use crate::utils::*;
 use chrono::naive::{NaiveDate, NaiveDateTime};
 use ocaml_interop::{
-    BoxRoot, DynBox, OCaml, OCamlBytes, OCamlFloat, OCamlInt, OCamlList, OCamlRef, OCamlRuntime,
-    ToOCaml,
+    BoxRoot, DynBox, FromOCaml, OCaml, OCamlBytes, OCamlFloat, OCamlInt, OCamlList, OCamlRef,
+    OCamlRuntime, ToOCaml,
 };
 use polars::prelude::prelude::*;
 use polars::prelude::*;
@@ -28,22 +28,32 @@ pub fn series_new(
     values: Vec<DummyBoxRoot>,
     are_values_options: bool,
 ) -> Result<Series, String> {
-    macro_rules! create_series {
-        ($ocaml_type:ty, $rust_type:ty) => {{
-            if are_values_options {
-                let values: Vec<Option<$rust_type>> = values
-                    .into_iter()
-                    .map(|v| v.interpret::<Option<$ocaml_type>>(cr).to_rust())
-                    .collect();
-                Ok(Series::new(&name, values))
-            } else {
-                let values: Vec<$rust_type> = values
-                    .into_iter()
-                    .map(|v| v.interpret::<$ocaml_type>(cr).to_rust())
-                    .collect();
-                Ok(Series::new(&name, values))
-            }
-        }};
+    fn create_series<MlType, RustType, V1, V2>(
+        cr: &mut OCamlRuntime,
+        are_values_options: bool,
+        name: &str,
+        values: Vec<DummyBoxRoot>,
+    ) -> polars::prelude::Series
+    where
+        polars::prelude::Series: polars::prelude::NamedFrom<Vec<Option<RustType>>, V1>,
+        polars::prelude::Series: polars::prelude::NamedFrom<Vec<RustType>, V2>,
+        V1: ?Sized,
+        V2: ?Sized,
+        RustType: FromOCaml<MlType>,
+    {
+        if are_values_options {
+            let values: Vec<Option<RustType>> = values
+                .into_iter()
+                .map(|v| v.interpret::<Option<MlType>>(cr).to_rust())
+                .collect();
+            (Series::new(&name, values))
+        } else {
+            let values: Vec<RustType> = values
+                .into_iter()
+                .map(|v| v.interpret::<MlType>(cr).to_rust())
+                .collect();
+            (Series::new(&name, values))
+        }
     }
 
     macro_rules! create_int_series {
@@ -72,7 +82,12 @@ pub fn series_new(
     }
 
     match data_type {
-        GADTDataType::Boolean => create_series!(bool, bool),
+        GADTDataType::Boolean => Ok(create_series::<bool, bool, _, _>(
+            cr,
+            are_values_options,
+            name,
+            values,
+        )),
         GADTDataType::UInt8 => create_int_series!(u8),
         GADTDataType::UInt16 => create_int_series!(u16),
         GADTDataType::UInt32 => create_int_series!(u32),
@@ -100,9 +115,24 @@ pub fn series_new(
                 Ok(Series::new(name, values))
             }
         }
-        GADTDataType::Float64 => create_series!(OCamlFloat, f64),
-        GADTDataType::Utf8 => create_series!(String, String),
-        GADTDataType::Binary => create_series!(OCamlBytes, Vec<u8>),
+        GADTDataType::Float64 => Ok(create_series::<OCamlFloat, f64, _, _>(
+            cr,
+            are_values_options,
+            name,
+            values,
+        )),
+        GADTDataType::Utf8 => Ok(create_series::<String, String, _, _>(
+            cr,
+            are_values_options,
+            name,
+            values,
+        )),
+        GADTDataType::Binary => Ok(create_series::<OCamlBytes, Vec<u8>, _, _>(
+            cr,
+            are_values_options,
+            name,
+            values,
+        )),
         GADTDataType::List(data_type) => {
             // Series creation doesn't work for empty lists and use of
             // `Series::new_empty` is suggested instead.

--- a/rust/polars-ocaml/src/sql_context.rs
+++ b/rust/polars-ocaml/src/sql_context.rs
@@ -90,7 +90,7 @@ fn rust_sql_context_execute(
 ) -> OCaml<Result<DynBox<LazyFrame>, String>> {
     let query: String = query.to_rust(cr);
 
-    dyn_box_result!(cr, |sql_context| {
+    dyn_box_result(cr, sql_context, |sql_context| {
         let result = sql_context.borrow_mut().execute(&query);
         result
     })

--- a/rust/polars-ocaml/src/utils.rs
+++ b/rust/polars-ocaml/src/utils.rs
@@ -24,29 +24,41 @@ macro_rules! dyn_box_legacy {
     };
 }
 
-pub fn dyn_box<'a, T, F, R>(cr: &'a mut OCamlRuntime, var: OCamlRef<DynBox<T>>, body: F) -> OCaml<'a, DynBox<R>>
+pub fn dyn_box<'a, T, F, R>(
+    cr: &'a mut OCamlRuntime,
+    var: OCamlRef<DynBox<T>>,
+    body: F,
+) -> OCaml<'a, DynBox<R>>
 where
     F: FnOnce(T) -> R,
     T: Clone + 'static,
-    R: 'static
+    R: 'static,
 {
     let Abstract(rust) = var.to_rust(cr);
     OCaml::box_value(cr, body(rust))
 }
 
-pub fn dyn_box_with_cr<'a, T, F, R>(cr: &'a mut OCamlRuntime, var: OCamlRef<DynBox<T>>, body: F) -> OCaml<'a, DynBox<R>>
+pub fn dyn_box_with_cr<'a, T, F, R>(
+    cr: &'a mut OCamlRuntime,
+    var: OCamlRef<DynBox<T>>,
+    body: F,
+) -> OCaml<'a, DynBox<R>>
 where
     F: FnOnce(&mut OCamlRuntime, T) -> R,
     T: Clone + 'static,
-    R: 'static
+    R: 'static,
 {
     let Abstract(rust) = var.to_rust(cr);
-    let v =  body(cr, rust);
+    let v = body(cr, rust);
     OCaml::box_value(cr, v)
 }
 
-
-pub fn dyn_box2<'a, T1, T2, F, R>(cr: &'a mut OCamlRuntime, var1: OCamlRef<DynBox<T1>>, var2: OCamlRef<DynBox<T2>>, body: F) -> OCaml<'a, DynBox<R>>
+pub fn dyn_box2<'a, T1, T2, F, R>(
+    cr: &'a mut OCamlRuntime,
+    var1: OCamlRef<DynBox<T1>>,
+    var2: OCamlRef<DynBox<T2>>,
+    body: F,
+) -> OCaml<'a, DynBox<R>>
 where
     F: FnOnce(T1, T2) -> R,
     T1: Clone + 'static,

--- a/rust/polars-ocaml/src/utils.rs
+++ b/rust/polars-ocaml/src/utils.rs
@@ -12,18 +12,6 @@ use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-macro_rules! dyn_box_legacy {
-    ($cr:ident, |$($var:ident),+| $body:expr) => {
-        {
-            $(
-                let Abstract($var) = $var.to_rust($cr);
-            )+
-
-            OCaml::box_value($cr, $body)
-        }
-    };
-}
-
 pub fn dyn_box<'a, T, F, R>(
     cr: &'a mut OCamlRuntime,
     var: OCamlRef<DynBox<T>>,
@@ -52,7 +40,6 @@ where
     let v = body(cr, rust);
     OCaml::box_value(cr, v)
 }
-
 
 pub fn dyn_box2<'a, T1, T2, F, R>(
     cr: &'a mut OCamlRuntime,
@@ -84,7 +71,10 @@ where
     Result<Abstract<R>, String>: ToOCaml<Result<DynBox<R>, String>>,
 {
     let Abstract(rust) = var.to_rust(cr);
-    body(rust).map(Abstract).map_err(|err| err.to_string()).to_ocaml(cr)
+    body(rust)
+        .map(Abstract)
+        .map_err(|err| err.to_string())
+        .to_ocaml(cr)
 }
 
 pub fn dyn_box_result_with_cr<'a, T, F, R, E>(
@@ -100,7 +90,10 @@ where
     Result<Abstract<R>, String>: ToOCaml<Result<DynBox<R>, String>>,
 {
     let Abstract(rust) = var.to_rust(cr);
-    body(cr, rust).map(Abstract).map_err(|err| err.to_string()).to_ocaml(cr)
+    body(cr, rust)
+        .map(Abstract)
+        .map_err(|err| err.to_string())
+        .to_ocaml(cr)
 }
 
 pub fn dyn_box_result2<'a, T1, T2, F, R, E>(
@@ -119,9 +112,23 @@ where
 {
     let Abstract(rust1) = v1.to_rust(cr);
     let Abstract(rust2) = v2.to_rust(cr);
-    body(rust1, rust2).map(Abstract).map_err(|err| err.to_string()).to_ocaml(cr)
+    body(rust1, rust2)
+        .map(Abstract)
+        .map_err(|err| err.to_string())
+        .to_ocaml(cr)
 }
 
+macro_rules! dyn_box_legacy {
+    ($cr:ident, |$($var:ident),+| $body:expr) => {
+        {
+            $(
+                let Abstract($var) = $var.to_rust($cr);
+            )+
+
+            OCaml::box_value($cr, $body)
+        }
+    };
+}
 
 macro_rules! dyn_box_result_legacy {
     ($cr:ident, |$($var:ident),+| $body:expr) => {


### PR DESCRIPTION
These trait bounds are kind of horrible but hopefully I can clean them up further in a future PR?

This still leaves some dyn_box macros for use within `dyn_box_op*` but I'm also optimistic I can migrate these places to also use functions in a subsequent PR. If you'd like me to clean them up in this PR first, let me know!