### PR TITLE
Add floatarray support

### DIFF
--- a/lib/series.ml
+++ b/lib/series.ml
@@ -33,6 +33,8 @@ module T = struct
      to pass regular arrays safely to Rust, whereas this is definitely safe
      since [Uniform_array.t] guarantees elements are boxed.
 
+     Conversely, [float'] can pass a [floatarray] which is guaranteed unboxed.
+
      See https://github.com/mt-caret/polars-ocaml/pull/67 for how naively trying to
      transmute on the Rust side doesn't work. *)
   external create'
@@ -62,6 +64,8 @@ module T = struct
       createo' data_type name (Uniform_array.map values ~f:(Option.map ~f:f_inverse))
     | data_type -> createo' data_type name values
   ;;
+
+  external float' : string -> floatarray -> t = "rust_series_new_float_array"
 
   let int = create Int64
   let into = createo Int64

--- a/lib/series.mli
+++ b/lib/series.mli
@@ -10,6 +10,7 @@ val int : string -> int list -> t
 val into : string -> int option list -> t
 val float : string -> float list -> t
 val floato : string -> float option list -> t
+val float' : string -> floatarray -> t
 val bool : string -> bool list -> t
 val boolo : string -> bool option list -> t
 val string : string -> string list -> t

--- a/lib/series.mli
+++ b/lib/series.mli
@@ -4,8 +4,8 @@ type t
 
 val create : 'a Data_type.Typed.t -> string -> 'a list -> t
 val createo : 'a Data_type.Typed.t -> string -> 'a option list -> t
-val create' : 'a Data_type.Typed.t -> string -> 'a Uniform_array.t -> t
-val createo' : 'a Data_type.Typed.t -> string -> 'a option Uniform_array.t -> t
+val create' : 'a Data_type.Typed.t -> string -> 'a array -> t
+val createo' : 'a Data_type.Typed.t -> string -> 'a option array -> t
 val int : string -> int list -> t
 val into : string -> int option list -> t
 val float : string -> float list -> t

--- a/rust/polars-ocaml/src/series.rs
+++ b/rust/polars-ocaml/src/series.rs
@@ -213,6 +213,17 @@ fn rust_series_new_option_array(
     OCaml::box_value(cr, Rc::new(RefCell::new(series)))
 }
 
+#[ocaml_interop_export(raise_on_err)]
+fn rust_series_new_float_array(
+    cr: &mut &mut OCamlRuntime,
+    name: OCamlRef<String>,
+    values: OCamlRef<OCamlFloatArray>,
+) -> OCaml<DynBox<PolarsSeries>> {
+    let name: String = name.to_rust(cr);
+    let values: Vec<f64> = values.to_rust(cr);
+    OCaml::box_value(cr, Rc::new(RefCell::new(Series::new(&name, values))))
+}
+
 #[ocaml_interop_export]
 fn rust_series_new_datetime(
     cr: &mut &mut OCamlRuntime,

--- a/rust/polars-ocaml/src/series.rs
+++ b/rust/polars-ocaml/src/series.rs
@@ -218,10 +218,25 @@ fn rust_series_new_float_array(
     cr: &mut &mut OCamlRuntime,
     name: OCamlRef<String>,
     values: OCamlRef<OCamlFloatArray>,
+    downcast_to_f32: OCamlRef<bool>,
 ) -> OCaml<DynBox<PolarsSeries>> {
     let name: String = name.to_rust(cr);
     let values: Vec<f64> = values.to_rust(cr);
-    OCaml::box_value(cr, Rc::new(RefCell::new(Series::new(&name, values))))
+    let downcast_to_f32: bool = downcast_to_f32.to_rust(cr);
+
+    let series = if downcast_to_f32 {
+        Series::new(
+            &name,
+            values
+                .into_iter()
+                .map(|f64| f64 as f32)
+                .collect::<Vec<f32>>(),
+        )
+    } else {
+        Series::new(&name, values)
+    };
+
+    OCaml::box_value(cr, Rc::new(RefCell::new(series)))
 }
 
 #[ocaml_interop_export]

--- a/rust/polars-ocaml/src/utils.rs
+++ b/rust/polars-ocaml/src/utils.rs
@@ -187,6 +187,27 @@ where
     }
 }
 
+// TODO: add this to ocaml-interop?
+pub struct OCamlFloatArray {}
+
+unsafe impl FromOCaml<OCamlFloatArray> for Vec<f64> {
+    fn from_ocaml(v: OCaml<OCamlFloatArray>) -> Self {
+        let size = unsafe { ocaml_sys::wosize_val(v.raw()) };
+
+        // an empty floatarray doesn't have the double array tag, but otherwise
+        // we always expect an unboxed float array.
+        if size > 0 {
+            assert_eq!(v.tag_value(), ocaml_sys::DOUBLE_ARRAY)
+        };
+
+        let mut vec = Vec::with_capacity(size);
+        for i in 0..size {
+            vec.push(unsafe { ocaml_sys::caml_sys_double_field(v.raw(), i) });
+        }
+        vec
+    }
+}
+
 pub struct OCamlInt63(pub i64);
 
 unsafe impl FromOCaml<OCamlInt63> for OCamlInt63 {

--- a/test/data_type_gadt_test.ml
+++ b/test/data_type_gadt_test.ml
@@ -184,9 +184,7 @@ let%expect_test "Series.create and Series.create' doesn't raise" =
         let value_equal = Comparable.equal (value_compare data_type) in
         assert (value_equal value (Series.get_exn data_type series i)));
       (* Test Series.create' *)
-      let series =
-        Series.create' data_type "series_name" (Uniform_array.of_list values)
-      in
+      let series = Series.create' data_type "series_name" (Array.of_list values) in
       let values' = Series.to_list data_type series in
       let args' = Series_create.Args (data_type, values') in
       [%test_result: Series_create.t] ~expect:args' args;
@@ -260,9 +258,7 @@ let%expect_test "Series.createo and Series.createo' doesn't raise" =
         let value_equal = Option.equal (Comparable.equal (value_compare data_type)) in
         assert (value_equal value (Series.get data_type series i)));
       (* Test Series.createo' *)
-      let series =
-        Series.createo' data_type "series_name" (Uniform_array.of_list values)
-      in
+      let series = Series.createo' data_type "series_name" (Array.of_list values) in
       let values' = Series.to_option_list data_type series in
       let args' = Series_createo.Args (data_type, values') in
       [%test_result: Series_createo.t] ~expect:args' args;

--- a/test/floatarray_test.ml
+++ b/test/floatarray_test.ml
@@ -1,0 +1,17 @@
+open Core
+open Polars
+
+let%expect_test "Series.float'" =
+  Base_quickcheck.Test.run_exn
+    (module struct
+      type t = float list [@@deriving sexp, quickcheck]
+    end)
+    ~f:(fun values ->
+      let series = Series.float' "series_name" (Stdlib.Float.Array.of_list values) in
+      let values' = Series.to_list Float64 series in
+      [%test_result: float list] ~expect:values values';
+      let values' = Series.to_option_list Float64 series |> List.filter_opt in
+      [%test_result: float list] ~expect:values values';
+      List.iteri values ~f:(fun i value ->
+        [%test_result: float] ~expect:value (Series.get_exn Float64 series i)))
+;;


### PR DESCRIPTION
Adds a way to create a `Series.t` via unboxed float arrays (via `floatarray`), and also removes the requirement of needing to use `Uniform_array.t`, obsoleting https://github.com/mt-caret/polars-ocaml/pull/67.