### PR TITLE
add GADT type accessors for durations

### DIFF
--- a/lib/data_type.ml
+++ b/lib/data_type.ml
@@ -55,6 +55,7 @@ module Typed = struct
     | Date : Naive_date.t t
     | Datetime : Time_unit.t * Tz.t option -> Naive_datetime.t t
     | Duration : Time_unit.t -> Duration.t t
+    | Time : Naive_time.t t
     | List : 'a t -> 'a list t
     | Custom :
         { data_type : 'a t
@@ -86,6 +87,7 @@ module Typed = struct
       else None
     | Duration tu1, Duration tu2 ->
       if [%compare.equal: Time_unit.t] tu1 tu2 then Some Type_equal.T else None
+    | Time, Time -> Some Type_equal.T
     | List t1, List t2 ->
       (match strict_type_equal t1 t2 with
        | None -> None
@@ -131,6 +133,7 @@ module Typed = struct
     | Date -> Date
     | Datetime (time_unit, time_zone) -> Datetime (time_unit, time_zone)
     | Duration time_unit -> Duration time_unit
+    | Time -> Time
     | List t -> List (to_untyped t)
     | Custom { data_type; f = _; f_inverse = _ } -> to_untyped data_type
   ;;
@@ -216,5 +219,10 @@ module Typed = struct
       ; f = Duration.to_span
       ; f_inverse = Duration.of_span
       }
+  ;;
+
+  let ofday =
+    Custom
+      { data_type = Time; f = Naive_time.to_ofday; f_inverse = Naive_time.of_ofday_exn }
   ;;
 end

--- a/lib/data_type.mli
+++ b/lib/data_type.mli
@@ -46,6 +46,7 @@ module Typed : sig
       | Date : Naive_date.t t
       | Datetime : Time_unit.t * Tz.t option -> Naive_datetime.t t
       | Duration : Time_unit.t -> Duration.t t
+      | Time : Naive_time.t t
       | List : 'a t -> 'a list t
       | Custom :
           { data_type : 'a t
@@ -71,5 +72,6 @@ module Typed : sig
     val date : Date.t t
     val time : Time_ns.t t
     val span : Time_ns.Span.t t
+    val ofday : Time_ns.Ofday.t t
   end
   with type untyped := t

--- a/lib/data_type.mli
+++ b/lib/data_type.mli
@@ -45,6 +45,7 @@ module Typed : sig
       | Binary : string t
       | Date : Naive_date.t t
       | Datetime : Time_unit.t * Tz.t option -> Naive_datetime.t t
+      | Duration : Time_unit.t -> Duration.t t
       | List : 'a t -> 'a list t
       | Custom :
           { data_type : 'a t
@@ -69,5 +70,6 @@ module Typed : sig
     val of_untyped : untyped -> packed option
     val date : Date.t t
     val time : Time_ns.t t
+    val span : Time_ns.Span.t t
   end
   with type untyped := t

--- a/lib/duration.ml
+++ b/lib/duration.ml
@@ -1,0 +1,21 @@
+open! Core
+
+type t
+
+external of_span : Time_ns.Span.t -> t = "rust_time_ns_span_to_duration"
+external to_nanoseconds : t -> int = "rust_duration_to_nanoseconds"
+
+let to_span t = to_nanoseconds t |> Time_ns.Span.of_int_ns
+
+let%expect_test "roundtrip" =
+  Quickcheck.test Time_ns.Span.quickcheck_generator ~f:(fun span ->
+    of_span span |> to_span |> [%test_result: Time_ns.Span.t] ~expect:span)
+;;
+
+module For_testing = struct
+  external round_to_time_unit
+    :  t
+    -> time_unit:Time_unit.t
+    -> t
+    = "rust_duration_round_to_time_unit"
+end

--- a/lib/duration.mli
+++ b/lib/duration.mli
@@ -1,0 +1,14 @@
+open! Core
+
+(** [Duration.t] is a timespan type used by polars.
+
+    The underlying Rust type is chrono::Duration
+    (https://docs.rs/chrono/latest/chrono/struct.Duration.html). *)
+type t
+
+val of_span : Time_ns.Span.t -> t
+val to_span : t -> Time_ns.Span.t
+
+module For_testing : sig
+  val round_to_time_unit : t -> time_unit:Time_unit.t -> t
+end

--- a/lib/naive_time.ml
+++ b/lib/naive_time.ml
@@ -1,0 +1,20 @@
+open! Core
+
+type t
+
+external of_ofday : Time_ns.Ofday.t -> t option = "rust_time_ns_ofday_to_time"
+
+let of_ofday_exn ofday =
+  of_ofday ofday |> Option.value_exn ~here:[%here] ~message:"invalid Time_ns.Ofday.t"
+;;
+
+external to_nanoseconds : t -> int = "rust_time_to_nanoseconds"
+
+let to_ofday t = Time_ns.Ofday.create ~ns:(to_nanoseconds t) ()
+
+let%expect_test "roundtrip" =
+  Quickcheck.test Time_ns.Ofday.quickcheck_generator ~f:(fun ofday ->
+    of_ofday ofday
+    |> Option.iter ~f:(fun t ->
+      to_ofday t |> [%test_result: Time_ns.Ofday.t] ~expect:ofday))
+;;

--- a/lib/naive_time.mli
+++ b/lib/naive_time.mli
@@ -1,0 +1,14 @@
+open! Core
+
+(** [Naive_time.t] is a type representing the time of day used by polars.
+
+    The underlying Rust type is chrono::NaiveTime
+    (https://docs.rs/chrono/latest/chrono/naive/struct.NaiveTime.html). *)
+type t
+
+(** Returns [None] if [Naive_date.t] does not support the [Time_ns.Ofday.t] value.
+    One example is [Time_ns.Ofday.of_string "24:00:00"]. *)
+val of_ofday : Time_ns.Ofday.t -> t option
+
+val of_ofday_exn : Time_ns.Ofday.t -> t
+val to_ofday : t -> Time_ns.Ofday.t

--- a/lib/polars.ml
+++ b/lib/polars.ml
@@ -1,6 +1,7 @@
 module Common = Common
 module Data_frame = Data_frame
 module Data_type = Data_type
+module Duration = Duration
 module Env = Env
 module Expr = Expr
 module Fill_null_strategy = Fill_null_strategy

--- a/lib/polars.ml
+++ b/lib/polars.ml
@@ -8,6 +8,7 @@ module Fill_null_strategy = Fill_null_strategy
 module Lazy_frame = Lazy_frame
 module Naive_date = Naive_date
 module Naive_datetime = Naive_datetime
+module Naive_time = Naive_time
 module Schema = Schema
 module Series = Series
 module Sql_context = Sql_context

--- a/rust/polars-ocaml/src/expr.rs
+++ b/rust/polars-ocaml/src/expr.rs
@@ -1,4 +1,4 @@
-use chrono::{NaiveDate, NaiveDateTime};
+use chrono::{Duration, NaiveDate, NaiveDateTime};
 use ocaml_interop::{
     DynBox, OCaml, OCamlBytes, OCamlFloat, OCamlInt, OCamlList, OCamlRef, OCamlRuntime, ToOCaml,
 };
@@ -127,6 +127,25 @@ fn rust_expr_lit(
             let time_zone = time_zone.map(|time_zone| time_zone.get().name().to_string());
 
             lit(LiteralValue::DateTime(timestamp, time_unit, time_zone))
+        }
+        GADTDataType::Duration(PolarsTimeUnit(time_unit)) => {
+            let duration = value
+                .interpret::<DynBox<Duration>>(cr)
+                .to_rust::<Abstract<Duration>>()
+                .get();
+
+            let duration = match time_unit {
+                TimeUnit::Nanoseconds => duration
+                    .num_nanoseconds()
+                    .ok_or_else(|| format!("out of range duration: {:?}", duration))?,
+                TimeUnit::Microseconds => duration
+                    .num_microseconds()
+                    .ok_or_else(|| format!("out of range duration: {:?}", duration))?,
+
+                TimeUnit::Milliseconds => duration.num_milliseconds(),
+            };
+
+            lit(LiteralValue::Duration(duration, time_unit))
         }
         GADTDataType::List(data_type) => {
             // Since there is no direct way to create a List-based literal, we

--- a/rust/polars-ocaml/src/expr.rs
+++ b/rust/polars-ocaml/src/expr.rs
@@ -1,4 +1,4 @@
-use chrono::{Duration, NaiveDate, NaiveDateTime};
+use chrono::{Duration, NaiveDate, NaiveDateTime, NaiveTime};
 use ocaml_interop::{
     DynBox, OCaml, OCamlBytes, OCamlFloat, OCamlInt, OCamlList, OCamlRef, OCamlRuntime, ToOCaml,
 };
@@ -146,6 +146,14 @@ fn rust_expr_lit(
             };
 
             lit(LiteralValue::Duration(duration, time_unit))
+        }
+        GADTDataType::Time => {
+            let time = value
+                .interpret::<DynBox<NaiveTime>>(cr)
+                .to_rust::<Abstract<NaiveTime>>()
+                .get();
+
+            lit(LiteralValue::Time(crate::misc::time_to_time64ns(&time)))
         }
         GADTDataType::List(data_type) => {
             // Since there is no direct way to create a List-based literal, we

--- a/rust/polars-ocaml/src/misc.rs
+++ b/rust/polars-ocaml/src/misc.rs
@@ -1,7 +1,7 @@
 use crate::utils::PolarsDataType;
 use crate::utils::*;
 use chrono::naive::{NaiveDate, NaiveDateTime};
-use chrono::Datelike;
+use chrono::{Datelike, Duration};
 use ocaml_interop::{DynBox, OCaml, OCamlInt, OCamlList, OCamlRef, ToOCaml};
 use polars::prelude::*;
 use polars_ocaml_macros::ocaml_interop_export;
@@ -122,6 +122,55 @@ fn rust_naive_datetime_round_to_time_unit(
     };
 
     Abstract(datetime).to_ocaml(cr)
+}
+
+#[ocaml_interop_export]
+fn rust_time_ns_span_to_duration(
+    cr: &mut &mut OCamlRuntime,
+    time_ns_span: OCamlRef<OCamlInt63>,
+) -> OCaml<DynBox<Duration>> {
+    let OCamlInt63(time_ns_span) = time_ns_span.to_rust(cr);
+
+    let duration = chrono::Duration::nanoseconds(time_ns_span);
+
+    Abstract(duration).to_ocaml(cr)
+}
+
+#[ocaml_interop_export(raise_on_err)]
+fn rust_duration_to_nanoseconds(
+    cr: &mut &mut OCamlRuntime,
+    duration: OCamlRef<DynBox<Duration>>,
+) -> OCaml<OCamlInt> {
+    let Abstract(duration) = duration.to_rust(cr);
+
+    duration
+        .num_nanoseconds()
+        .ok_or_else(|| format!("out of range duration: {:?}", duration))?
+        .to_ocaml(cr)
+}
+
+#[ocaml_interop_export(raise_on_err)]
+fn rust_duration_round_to_time_unit(
+    cr: &mut &mut OCamlRuntime,
+    duration: OCamlRef<DynBox<Duration>>,
+    time_unit: OCamlRef<TimeUnit>,
+) -> OCaml<DynBox<Duration>> {
+    let Abstract(duration) = duration.to_rust(cr);
+    let PolarsTimeUnit(time_unit) = time_unit.to_rust(cr);
+
+    let duration = match time_unit {
+        TimeUnit::Nanoseconds => duration,
+        TimeUnit::Microseconds => arrow2::temporal_conversions::duration_us_to_duration(
+            duration
+                .num_microseconds()
+                .ok_or_else(|| format!("out of range duration: {:?}", duration))?,
+        ),
+        TimeUnit::Milliseconds => {
+            arrow2::temporal_conversions::duration_ms_to_duration(duration.num_milliseconds())
+        }
+    };
+
+    Abstract(duration).to_ocaml(cr)
 }
 
 #[ocaml_interop_export]

--- a/rust/polars-ocaml/src/series.rs
+++ b/rust/polars-ocaml/src/series.rs
@@ -1,5 +1,6 @@
 use crate::utils::*;
 use chrono::naive::{NaiveDate, NaiveDateTime};
+use chrono::Duration;
 use ocaml_interop::{
     BoxRoot, DynBox, OCaml, OCamlBytes, OCamlFloat, OCamlInt, OCamlList, OCamlRef, OCamlRuntime,
     ToOCaml,
@@ -148,6 +149,23 @@ pub fn series_new(
                     .map(|Abstract(naive_datetime)| naive_datetime);
 
                 Ok(Logical::from_naive_datetime(name, values, *time_unit).into())
+            }
+        }
+        GADTDataType::Duration(PolarsTimeUnit(time_unit)) => {
+            if are_values_options {
+                let values = values
+                    .into_iter()
+                    .map(|v| v.interpret::<Option<DynBox<Duration>>>(cr).to_rust())
+                    .map(|v: Option<Abstract<Duration>>| v.map(|Abstract(duration)| duration));
+
+                Ok(Logical::from_duration_options(name, values, *time_unit).into())
+            } else {
+                let values = values
+                    .into_iter()
+                    .map(|v| v.interpret::<DynBox<Duration>>(cr).to_rust())
+                    .map(|Abstract(duration)| duration);
+
+                Ok(Logical::from_duration(name, values, *time_unit).into())
             }
         }
         GADTDataType::List(data_type) => {
@@ -337,7 +355,7 @@ fn rust_series_date_range(
         &name,
         start,
         stop,
-        Duration::parse(&every),
+        polars::prelude::Duration::parse(&every),
         ClosedWindow::Both,
         TimeUnit::Milliseconds,
         None,
@@ -523,18 +541,14 @@ fn series_to_boxrooted_ocaml_list(
             }
         }
         GADTDataType::Datetime(PolarsTimeUnit(time_unit), _time_zone) => {
+            let timestamp_to_datetime = match time_unit {
+                TimeUnit::Nanoseconds => arrow2::temporal_conversions::timestamp_ns_to_datetime,
+                TimeUnit::Microseconds => arrow2::temporal_conversions::timestamp_us_to_datetime,
+                TimeUnit::Milliseconds => arrow2::temporal_conversions::timestamp_ms_to_datetime,
+            };
+
             if matches!(series.dtype(), DataType::Int64) {
                 let ca = series.i64().map_err(|err| err.to_string())?;
-
-                let timestamp_to_datetime = match time_unit {
-                    TimeUnit::Nanoseconds => arrow2::temporal_conversions::timestamp_ns_to_datetime,
-                    TimeUnit::Microseconds => {
-                        arrow2::temporal_conversions::timestamp_us_to_datetime
-                    }
-                    TimeUnit::Milliseconds => {
-                        arrow2::temporal_conversions::timestamp_ms_to_datetime
-                    }
-                };
 
                 create_boxrooted_ocaml_list_handle_nulls!(
                     Abstract<NaiveDateTime>,
@@ -563,23 +577,61 @@ fn series_to_boxrooted_ocaml_list(
                     ca.as_datetime_iter().map(|o| o.map(Abstract)).collect(),
                     {
                         let mut buf = Vec::with_capacity(ca.len());
-
-                        let timestamp_to_datetime = match time_unit {
-                            TimeUnit::Nanoseconds => {
-                                arrow2::temporal_conversions::timestamp_ns_to_datetime
-                            }
-                            TimeUnit::Microseconds => {
-                                arrow2::temporal_conversions::timestamp_us_to_datetime
-                            }
-                            TimeUnit::Milliseconds => {
-                                arrow2::temporal_conversions::timestamp_ms_to_datetime
-                            }
-                        };
-
                         for arr in ca.downcast_iter() {
                             buf.extend(
                                 arr.values_iter()
                                     .map(|timestamp| Abstract(timestamp_to_datetime(*timestamp))),
+                            )
+                        }
+                        buf
+                    }
+                )
+            }
+        }
+        GADTDataType::Duration(PolarsTimeUnit(time_unit)) => {
+            let duration_conversion = match time_unit {
+                TimeUnit::Nanoseconds => arrow2::temporal_conversions::duration_ns_to_duration,
+                TimeUnit::Microseconds => arrow2::temporal_conversions::duration_us_to_duration,
+                TimeUnit::Milliseconds => arrow2::temporal_conversions::duration_ms_to_duration,
+            };
+
+            if matches!(series.dtype(), DataType::Int64) {
+                let ca = series.i64().map_err(|err| err.to_string())?;
+
+                create_boxrooted_ocaml_list_handle_nulls!(
+                    Abstract<Duration>,
+                    DynBox<Duration>,
+                    ca.into_iter()
+                        .map(|o| o.map(|i64| { Abstract(duration_conversion(i64)) }))
+                        .collect(),
+                    {
+                        let mut buf = Vec::with_capacity(ca.len());
+
+                        for arr in ca.downcast_iter() {
+                            buf.extend(
+                                arr.values_iter()
+                                    .map(|timestamp| Abstract(duration_conversion(*timestamp))),
+                            )
+                        }
+                        buf
+                    }
+                )
+            } else {
+                let ca = series.duration().map_err(|err| err.to_string())?;
+
+                create_boxrooted_ocaml_list_handle_nulls!(
+                    Abstract<Duration>,
+                    DynBox<Duration>,
+                    ca.downcast_iter()
+                        .flat_map(|iter| iter.into_iter())
+                        .map(|o| o.map(|duration| Abstract(duration_conversion(*duration))))
+                        .collect(),
+                    {
+                        let mut buf = Vec::with_capacity(ca.len());
+                        for arr in ca.downcast_iter() {
+                            buf.extend(
+                                arr.values_iter()
+                                    .map(|timestamp| Abstract(duration_conversion(*timestamp))),
                             )
                         }
                         buf
@@ -754,6 +806,28 @@ fn series_get(
                         }
                     };
                     Abstract(timestamp_to_datetime(datetime))
+                })
+        ),
+        GADTDataType::Duration(PolarsTimeUnit(time_unit)) => extract_value!(
+            Abstract<Duration>,
+            DynBox<Duration>,
+            series
+                .duration()
+                .map_err(|err| err.to_string())?
+                .get(index)
+                .map(|duration| {
+                    let duration_conversion = match time_unit {
+                        TimeUnit::Nanoseconds => {
+                            arrow2::temporal_conversions::duration_ns_to_duration
+                        }
+                        TimeUnit::Microseconds => {
+                            arrow2::temporal_conversions::duration_us_to_duration
+                        }
+                        TimeUnit::Milliseconds => {
+                            arrow2::temporal_conversions::duration_ms_to_duration
+                        }
+                    };
+                    Abstract(duration_conversion(duration))
                 })
         ),
         GADTDataType::List(data_type) => extract_value!(

--- a/rust/polars-ocaml/src/utils.rs
+++ b/rust/polars-ocaml/src/utils.rs
@@ -384,6 +384,7 @@ pub enum GADTDataType {
     Binary,
     Date,
     Datetime(PolarsTimeUnit, Option<Abstract<chrono_tz::Tz>>),
+    Duration(PolarsTimeUnit),
     List(Box<GADTDataType>),
 }
 
@@ -404,6 +405,7 @@ impl_from_ocaml_variant! {
         GADTDataType::Binary,
         GADTDataType::Date,
         GADTDataType::Datetime(time_unit: TimeUnit, time_zone: Option<DynBox<chrono_tz::Tz>>),
+        GADTDataType::Duration(time_unit: TimeUnit),
         GADTDataType::List(data_type: GADTDataType),
     }
 }
@@ -431,6 +433,7 @@ impl GADTDataType {
                     .clone()
                     .map(|time_zone| time_zone.get().name().to_string()),
             ),
+            GADTDataType::Duration(time_unit) => DataType::Duration(time_unit.0),
             GADTDataType::List(data_type) => DataType::List(Box::new(data_type.to_data_type())),
         }
     }

--- a/rust/polars-ocaml/src/utils.rs
+++ b/rust/polars-ocaml/src/utils.rs
@@ -385,6 +385,7 @@ pub enum GADTDataType {
     Date,
     Datetime(PolarsTimeUnit, Option<Abstract<chrono_tz::Tz>>),
     Duration(PolarsTimeUnit),
+    Time,
     List(Box<GADTDataType>),
 }
 
@@ -406,6 +407,7 @@ impl_from_ocaml_variant! {
         GADTDataType::Date,
         GADTDataType::Datetime(time_unit: TimeUnit, time_zone: Option<DynBox<chrono_tz::Tz>>),
         GADTDataType::Duration(time_unit: TimeUnit),
+        GADTDataType::Time,
         GADTDataType::List(data_type: GADTDataType),
     }
 }
@@ -434,6 +436,7 @@ impl GADTDataType {
                     .map(|time_zone| time_zone.get().name().to_string()),
             ),
             GADTDataType::Duration(time_unit) => DataType::Duration(time_unit.0),
+            GADTDataType::Time => DataType::Time,
             GADTDataType::List(data_type) => DataType::List(Box::new(data_type.to_data_type())),
         }
     }


### PR DESCRIPTION
Adds a GADT type accessor for `Duration.t`, and allow conversion back and forth between `Time_ns.Span.t`.