### PR TITLE
add GADT type accessors for time of day

### DIFF
--- a/lib/data_type.ml
+++ b/lib/data_type.ml
@@ -55,6 +55,7 @@ module Typed = struct
     | Date : Naive_date.t t
     | Datetime : Time_unit.t * Tz.t option -> Naive_datetime.t t
     | Duration : Time_unit.t -> Duration.t t
+    | Time : Naive_time.t t
     | List : 'a t -> 'a list t
     | Custom :
         { data_type : 'a t
@@ -86,6 +87,7 @@ module Typed = struct
       else None
     | Duration tu1, Duration tu2 ->
       if [%compare.equal: Time_unit.t] tu1 tu2 then Some Type_equal.T else None
+    | Time, Time -> Some Type_equal.T
     | List t1, List t2 ->
       (match strict_type_equal t1 t2 with
        | None -> None
@@ -131,6 +133,7 @@ module Typed = struct
     | Date -> Date
     | Datetime (time_unit, time_zone) -> Datetime (time_unit, time_zone)
     | Duration time_unit -> Duration time_unit
+    | Time -> Time
     | List t -> List (to_untyped t)
     | Custom { data_type; f = _; f_inverse = _ } -> to_untyped data_type
   ;;
@@ -216,5 +219,10 @@ module Typed = struct
       ; f = Duration.to_span
       ; f_inverse = Duration.of_span
       }
+  ;;
+
+  let ofday =
+    Custom
+      { data_type = Time; f = Naive_time.to_ofday; f_inverse = Naive_time.of_ofday_exn }
   ;;
 end

--- a/lib/data_type.mli
+++ b/lib/data_type.mli
@@ -46,6 +46,7 @@ module Typed : sig
       | Date : Naive_date.t t
       | Datetime : Time_unit.t * Tz.t option -> Naive_datetime.t t
       | Duration : Time_unit.t -> Duration.t t
+      | Time : Naive_time.t t
       | List : 'a t -> 'a list t
       | Custom :
           { data_type : 'a t
@@ -71,5 +72,6 @@ module Typed : sig
     val date : Date.t t
     val time : Time_ns.t t
     val span : Time_ns.Span.t t
+    val ofday : Time_ns.Ofday.t t
   end
   with type untyped := t

--- a/lib/naive_time.ml
+++ b/lib/naive_time.ml
@@ -1,0 +1,20 @@
+open! Core
+
+type t
+
+external of_ofday : Time_ns.Ofday.t -> t option = "rust_time_ns_ofday_to_time"
+
+let of_ofday_exn ofday =
+  of_ofday ofday |> Option.value_exn ~here:[%here] ~message:"invalid Time_ns.Ofday.t"
+;;
+
+external to_nanoseconds : t -> int = "rust_time_to_nanoseconds"
+
+let to_ofday t = Time_ns.Ofday.create ~ns:(to_nanoseconds t) ()
+
+let%expect_test "roundtrip" =
+  Quickcheck.test Time_ns.Ofday.quickcheck_generator ~f:(fun ofday ->
+    of_ofday ofday
+    |> Option.iter ~f:(fun t ->
+      to_ofday t |> [%test_result: Time_ns.Ofday.t] ~expect:ofday))
+;;

--- a/lib/naive_time.mli
+++ b/lib/naive_time.mli
@@ -1,0 +1,14 @@
+open! Core
+
+(** [Naive_time.t] is a type representing the time of day used by polars.
+
+    The underlying Rust type is chrono::NaiveTime
+    (https://docs.rs/chrono/latest/chrono/naive/struct.NaiveTime.html). *)
+type t
+
+(** Returns [None] if [Naive_date.t] does not support the [Time_ns.Ofday.t] value.
+    One example is [Time_ns.Ofday.of_string "24:00:00"]. *)
+val of_ofday : Time_ns.Ofday.t -> t option
+
+val of_ofday_exn : Time_ns.Ofday.t -> t
+val to_ofday : t -> Time_ns.Ofday.t

--- a/lib/polars.ml
+++ b/lib/polars.ml
@@ -8,6 +8,7 @@ module Fill_null_strategy = Fill_null_strategy
 module Lazy_frame = Lazy_frame
 module Naive_date = Naive_date
 module Naive_datetime = Naive_datetime
+module Naive_time = Naive_time
 module Schema = Schema
 module Series = Series
 module Sql_context = Sql_context

--- a/rust/polars-ocaml/src/expr.rs
+++ b/rust/polars-ocaml/src/expr.rs
@@ -1,4 +1,4 @@
-use chrono::{Duration, NaiveDate, NaiveDateTime};
+use chrono::{Duration, NaiveDate, NaiveDateTime, NaiveTime};
 use ocaml_interop::{
     DynBox, OCaml, OCamlBytes, OCamlFloat, OCamlInt, OCamlList, OCamlRef, OCamlRuntime, ToOCaml,
 };
@@ -146,6 +146,14 @@ fn rust_expr_lit(
             };
 
             lit(LiteralValue::Duration(duration, time_unit))
+        }
+        GADTDataType::Time => {
+            let time = value
+                .interpret::<DynBox<NaiveTime>>(cr)
+                .to_rust::<Abstract<NaiveTime>>()
+                .get();
+
+            lit(LiteralValue::Time(crate::misc::time_to_time64ns(&time)))
         }
         GADTDataType::List(data_type) => {
             // Since there is no direct way to create a List-based literal, we

--- a/rust/polars-ocaml/src/utils.rs
+++ b/rust/polars-ocaml/src/utils.rs
@@ -385,6 +385,7 @@ pub enum GADTDataType {
     Date,
     Datetime(PolarsTimeUnit, Option<Abstract<chrono_tz::Tz>>),
     Duration(PolarsTimeUnit),
+    Time,
     List(Box<GADTDataType>),
 }
 
@@ -406,6 +407,7 @@ impl_from_ocaml_variant! {
         GADTDataType::Date,
         GADTDataType::Datetime(time_unit: TimeUnit, time_zone: Option<DynBox<chrono_tz::Tz>>),
         GADTDataType::Duration(time_unit: TimeUnit),
+        GADTDataType::Time,
         GADTDataType::List(data_type: GADTDataType),
     }
 }
@@ -434,6 +436,7 @@ impl GADTDataType {
                     .map(|time_zone| time_zone.get().name().to_string()),
             ),
             GADTDataType::Duration(time_unit) => DataType::Duration(time_unit.0),
+            GADTDataType::Time => DataType::Time,
             GADTDataType::List(data_type) => DataType::List(Box::new(data_type.to_data_type())),
         }
     }


### PR DESCRIPTION
Adds a GADT type accessor for `Naive_time.t`, and allow conversion back and forth between `Time_ns.Ofday.t`.