### PR TITLE
Tweak opam files

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -44,6 +44,16 @@
  (name polars_async)
  (synopsis "Async OCaml bindings to the Polars dataframe library")
  (description "Async OCaml bindings to the Polars dataframe library")
- (depends polars async core)
+ (depends
+  (core_bench :with-test)
+  (expect_test_helpers_core :with-test)
+  (mdx :with-test)
+  (ocamlformat :dev)
+  (odoc :with-doc)
+  (re2 :with-test)
+  (shell :with-test)
+  async
+  core
+  polars)
  (tags
   (data-science polars rust)))

--- a/dune-project
+++ b/dune-project
@@ -34,7 +34,9 @@
   core_kernel
   core_unix
   dune
-  ocaml
+  ; ocaml-interop does not yet properly support OCaml 5
+  (ocaml
+   (< 5.0.0))
   ppx_jane
   ppx_typed_fields)
  (tags

--- a/polars.opam
+++ b/polars.opam
@@ -26,6 +26,7 @@ depends: [
   "ppx_jane"
   "ppx_typed_fields"
 ]
+dev-repo: "git+https://github.com/mt-caret/polars-ocaml.git"
 build: [
   ["dune" "subst"] {dev}
   [
@@ -36,11 +37,12 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    # We do not run the @runtest target, since some of our tests depend on
+    # polars-async, and this causes opam's CI to complain about missing dependencies
+    # "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/mt-caret/polars-ocaml.git"
 # 32bit is not supported, and the combination of macos+arm64 is known to not
 # work due to issues in DWARF unwinding in OCaml
 available: (os = "linux" & (arch = "x86_64" | arch = "arm64")) | (os = "macos" & arch = "x86_64")

--- a/polars.opam
+++ b/polars.opam
@@ -22,7 +22,7 @@ depends: [
   "core_kernel"
   "core_unix"
   "dune" {>= "3.8"}
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ppx_jane"
   "ppx_typed_fields"
 ]

--- a/polars.opam.template
+++ b/polars.opam.template
@@ -1,3 +1,19 @@
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    # We do not run the @runtest target, since some of our tests depend on
+    # polars-async, and this causes opam's CI to complain about missing dependencies
+    # "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
 # 32bit is not supported, and the combination of macos+arm64 is known to not
 # work due to issues in DWARF unwinding in OCaml
 available: (os = "linux" & (arch = "x86_64" | arch = "arm64")) | (os = "macos" & arch = "x86_64")

--- a/polars_async.opam
+++ b/polars_async.opam
@@ -11,10 +11,16 @@ doc: "https://github.com/mt-caret/polars-ocaml"
 bug-reports: "https://github.com/mt-caret/polars-ocaml/issues"
 depends: [
   "dune" {>= "3.8"}
-  "polars"
+  "core_bench" {with-test}
+  "expect_test_helpers_core" {with-test}
+  "mdx" {with-test}
+  "ocamlformat" {dev}
+  "odoc" {with-doc}
+  "re2" {with-test}
+  "shell" {with-test}
   "async"
   "core"
-  "odoc" {with-doc}
+  "polars"
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Shuffle around some version constraints so that opam's CI doesn't complain, and add OCaml version constraint.