### PR TITLE
Added Expr.log and Expr.exp

### DIFF
--- a/lib/expr.ml
+++ b/lib/expr.ml
@@ -204,8 +204,21 @@ module T = struct
   external mul : t -> t -> t = "rust_expr_mul"
   external div : t -> t -> t = "rust_expr_div"
   external floor_div : t -> t -> t = "rust_expr_floor_div"
+  external abs : t -> t = "rust_expr_abs"
   external exp : t -> t = "rust_expr_exp"
-  external log : t -> t -> t = "rust_expr_log"
+  external log : t -> float -> t = "rust_expr_log"
+
+  let log
+    ?(base =
+      (* Surprisingly, Euler's number is not present in Core. And no,
+         [Float.euler] is not Euler's number! *)
+      Float.exp 1.)
+    t
+    =
+    log t base
+  ;;
+
+  external log1p : t -> t = "rust_expr_log1p"
 
   let ( // ) = floor_div
 end

--- a/lib/expr.ml
+++ b/lib/expr.ml
@@ -204,6 +204,8 @@ module T = struct
   external mul : t -> t -> t = "rust_expr_mul"
   external div : t -> t -> t = "rust_expr_div"
   external floor_div : t -> t -> t = "rust_expr_floor_div"
+  external exp : t -> t = "rust_expr_exp"
+  external log : t -> t -> t = "rust_expr_log"
 
   let ( // ) = floor_div
 end

--- a/lib/expr.mli
+++ b/lib/expr.mli
@@ -989,6 +989,10 @@ include Common.Numeric with type t := t
 (* TODO: apparently this doesn't exist for series, which is surprising! *)
 val floor_div : t -> t -> t
 val ( // ) : t -> t -> t
+val abs : t -> t
+val exp : t -> t
+val log : ?base:float -> t -> t
+val log1p : t -> t
 
 module Dt : sig
   val strftime : t -> format:string -> t

--- a/rust/polars-ocaml/src/expr.rs
+++ b/rust/polars-ocaml/src/expr.rs
@@ -637,7 +637,16 @@ expr_op!(rust_expr_mul, |expr, other| expr * other);
 expr_op!(rust_expr_div, |expr, other| expr / other);
 expr_op!(rust_expr_floor_div, |expr, other| expr.floor_div(other));
 expr_op!(rust_expr_exp, |expr| expr.exp());
-expr_op!(rust_expr_log, |expr, base| expr.log(base)); 
+
+#[ocaml_interop_export]
+fn rust_expr_log_float(
+    cr: &mut &mut OCamlRuntime,
+    expr: OCamlRef<DynBox<Expr>>,
+    base: OCamlRef<OCamlFloat>,
+) -> OCaml<DynBox<Expr>> {
+    let base: f64 = base.to_rust(cr);
+    dyn_box(cr, expr, |expr| expr.log(base))
+}
 
 #[ocaml_interop_export]
 fn rust_expr_dt_strftime(

--- a/rust/polars-ocaml/src/expr.rs
+++ b/rust/polars-ocaml/src/expr.rs
@@ -636,6 +636,8 @@ expr_op!(rust_expr_sub, |expr, other| expr - other);
 expr_op!(rust_expr_mul, |expr, other| expr * other);
 expr_op!(rust_expr_div, |expr, other| expr / other);
 expr_op!(rust_expr_floor_div, |expr, other| expr.floor_div(other));
+expr_op!(rust_expr_exp, |expr| expr.exp());
+expr_op!(rust_expr_log, |expr, base| expr.log(base)); 
 
 #[ocaml_interop_export]
 fn rust_expr_dt_strftime(

--- a/rust/polars-ocaml/src/expr.rs
+++ b/rust/polars-ocaml/src/expr.rs
@@ -636,10 +636,12 @@ expr_op!(rust_expr_sub, |expr, other| expr - other);
 expr_op!(rust_expr_mul, |expr, other| expr * other);
 expr_op!(rust_expr_div, |expr, other| expr / other);
 expr_op!(rust_expr_floor_div, |expr, other| expr.floor_div(other));
+expr_op!(rust_expr_abs, |expr| expr.abs());
 expr_op!(rust_expr_exp, |expr| expr.exp());
+expr_op!(rust_expr_log1p, |expr| expr.log1p());
 
 #[ocaml_interop_export]
-fn rust_expr_log_float(
+fn rust_expr_log(
     cr: &mut &mut OCamlRuntime,
     expr: OCamlRef<DynBox<Expr>>,
     base: OCamlRef<OCamlFloat>,


### PR DESCRIPTION
I have some problems building locally:
```
dune build @fmt @runtest @doc -w --auto-promote
Error: fswatch (or inotifywait) was not found. One of them needs to be installed for watch mode to work.
```
But I want to see if it passes the checks when doing a PR.