### PR TITLE
Add minimum supported rust version and verify it in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,6 +73,7 @@ jobs:
           cacheFrom: ghcr.io/mt-caret/polars-ocaml
           push: always
           runCmd: |
+            apt install --yes pkg-config
             cargo install cargo-msrv
             cd ./rust/polars-ocaml && cargo msrv verify
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,7 +73,7 @@ jobs:
           cacheFrom: ghcr.io/mt-caret/polars-ocaml
           push: always
           runCmd: |
-            cargo install msrv
+            cargo install cargo-msrv
             cd ./rust/polars-ocaml && cargo msrv verify
 
   rust-checks:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,9 +8,9 @@ on:
   # Since cargo and opam dependencies change over time, we schedule a build of
   # the container every week so we can catch issues early on
   schedule:
-      # Run at 1AM UTC every Saturday; this translates to 9AM HKT and 9PM EST
-      # (new york outside of DST)
-      - cron: '0 1 * * 6'
+    # Run at 1AM UTC every Saturday; this translates to 9AM HKT and 9PM EST
+    # (new york outside of DST)
+    - cron: "0 1 * * 6"
 
 env:
   CARGO_TERM_COLOR: always
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2 
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -49,6 +49,32 @@ jobs:
           runCmd: |
             opam exec -- dune build
             opam exec -- dune runtest
+
+  verify-minimum-supported-rust-version:
+    runs-on: self-hosted
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout (GitHub)
+        uses: actions/checkout@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name:
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ghcr.io/mt-caret/polars-ocaml
+          cacheFrom: ghcr.io/mt-caret/polars-ocaml
+          push: always
+          runCmd: |
+            cargo install msrv
+            cd ./rust/polars-ocaml && cargo msrv verify
 
   rust-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,7 +73,7 @@ jobs:
           cacheFrom: ghcr.io/mt-caret/polars-ocaml
           push: always
           runCmd: |
-            apt install --yes pkg-config
+            apt install --yes pkg-config libssl-dev
             cargo install cargo-msrv
             cd ./rust/polars-ocaml && cargo msrv verify
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,7 +1,10 @@
 [workspace]
 resolver = "2"
-
 members = [
     "polars-ocaml",
     "polars-ocaml-macros"
 ]
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"

--- a/rust/polars-ocaml-macros/Cargo.toml
+++ b/rust/polars-ocaml-macros/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "polars-ocaml-macros"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 proc-macro2 = "^1.0.60"

--- a/rust/polars-ocaml/Cargo.toml
+++ b/rust/polars-ocaml/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "polars-ocaml"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+# Once cargo-msrv supports using workspace inheritance, move this into ../Cargo.toml:
+# https://github.com/foresterre/cargo-msrv/issues/590
+rust-version = "1.70.0"
 
 [lib]
 crate-type = ["staticlib", "cdylib"]


### PR DESCRIPTION
It's unclear to folks what the minimum required rust version is, and it seems like this is something that can be automatically determined and verified using [cargo-msrv](https://github.com/foresterre/cargo-msrv). This PR adds the msrv and also a CI job that makes sure that we don't forget to bump it.