### PR TITLE
Add `packages: write` permission to odoc workflow in CI

### DIFF
--- a/.github/workflows/odoc.yaml
+++ b/.github/workflows/odoc.yaml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
       pages: write
 
     steps:


### PR DESCRIPTION
Apparently this is needed for Dev Containers.