### PR TITLE
Switch to ocaml/opam image to sidestep weird opam init issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,21 @@
-FROM ubuntu:22.04
+FROM ocaml/opam:ubuntu-22.04-ocaml-4.14
 
 LABEL org.opencontainers.image.source=https://github.com/mt-caret/polars-ocaml
 
-RUN apt-get update && apt-get install -y \
+RUN DEBIAN_FRONTEND=noninteractive sudo apt-get update && sudo apt-get install -y \
     curl \
     build-essential \
-    opam \
     mold
-RUN opam init --auto-setup --compiler=4.14.1 --disable-sandboxing
+
+# Overwrite default linker with mold (this drastically speeds up builds)
+RUN sudo ln -sf /usr/bin/mold "$(realpath /usr/bin/ld)"
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     sh -s -- -y --default-toolchain=nightly
-ENV PATH="/root/.cargo/bin:${PATH}"
+ENV PATH="${HOME}/.cargo/bin:${PATH}"
 
-RUN opam install dune ocamlformat ocaml-lsp-server --yes
-RUN cargo install cargo-watch
+RUN sudo ln -f /usr/bin/opam-2.2 /usr/bin/opam
+RUN opam install dune ocamlformat ocaml-lsp-server --yes && cargo install cargo-watch
 
-COPY ./polars.opam ./polars_async.opam ./
+COPY --chown=opam ./polars.opam ./polars_async.opam ./
 RUN opam install . --deps-only --with-doc --with-test --assume-depexts --yes
-
-# Overwrite default linker with mold (this drastically speeds up builds)
-RUN ln -sf /usr/bin/mold "$(realpath /usr/bin/ld)"


### PR DESCRIPTION
`opam init` fails for a weird reason, and since opam suppresses stderr/stdout for this particular command, I can't be bothered to try and debug this.

Taking inspiration from https://github.com/mt-caret/polars-ocaml/pull/114 we switch to opam's official image which seems to not exhibit this issue.